### PR TITLE
feat(sdlc): impact analysis agent two-pass exploration (#16)

### DIFF
--- a/.claude/plugins/sdlc/agents/impact-analysis-agent/AGENT.md
+++ b/.claude/plugins/sdlc/agents/impact-analysis-agent/AGENT.md
@@ -35,9 +35,9 @@ gh issue list --state open --json number,title,labels --limit 200
 ```
 
 From this list, identify **candidates** worth deep-reading. An issue is a candidate if ANY of these are true:
-- Shares an area label with the draft (e.g., draft has `area:skills`, issue has `area:skills`)
 - Is referenced in the draft's Dependencies section (`Blocked by` or `Blocks`)
 - Is a parent, child, or sibling of the draft's artifact (same parent epic/feature)
+- Shares an area label with the draft (e.g., draft has `area:skills`, issue has `area:skills`)
 - Title contains keywords that overlap with the draft's description or name
 - Has `triage` label (might be addressed or superseded by the new artifact)
 
@@ -64,7 +64,7 @@ Regardless of pass results, always read:
 ### Step 5: Traverse Dependency Graph
 
 For each issue number found in the draft's Dependencies section:
-1. Read the referenced issue's body (if not already read in Pass 2)
+1. Read the referenced issue's body. If already read during Pass 2, reuse that data — do not re-fetch.
 2. Check if its `Blocks:` or `Blocked by:` line needs updating to include the new artifact
 3. If the referenced issue itself has dependencies, check **one level deep** for transitive impacts (e.g., unblocking a chain)
 


### PR DESCRIPTION
## Summary
- Rewrites impact-analysis-agent with two-pass exploration strategy: wide scan of all open issues (Pass 1), then deep-read only matching candidates (Pass 2)
- Adds `reclassification-cascade` impact category for type changes between draft and existing issues
- Updates calibration section with explicit "Flag these" / "Do NOT flag" guidance for broader scanning
- Adds dependency graph traversal (max 2 levels deep)
- Updates frontmatter phase reference to Phase 9 (per story #15 renumbering)

## Test Plan
- [ ] Verify AGENT.md has all 6 process steps (Read Draft, Wide Scan, Deep Read, Read PI/PRD, Traverse Dependencies, Scan Categories)
- [ ] Verify all 8 impact categories listed including reclassification-cascade with subsection
- [ ] Verify calibration has "Flag these" (6 items) and "Do NOT flag" (6 items)
- [ ] Verify output format includes reclassification-cascade in category list
- [ ] Verify no other files were modified

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)