### PR TITLE
feat(status): rewrite with hierarchy-aware dashboard

### DIFF
--- a/.claude/plugins/sdlc/skills/status/SKILL.md
+++ b/.claude/plugins/sdlc/skills/status/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: status
-description: Use to get a project status briefing — what's in progress, blocked, ready, and what can run in parallel. Read-only, never modifies anything.
+description: Use to get a project status briefing — walks the hierarchy top-down from PI to stories, surfaces what's in progress, blocked, and ready with impact-ranked next actions. Read-only, never modifies anything.
 allowed-tools: Read, Bash, Grep, Glob
 argument-hint: "[area or 'epic #N']"
 ---
@@ -19,258 +19,286 @@ Do NOT modify issues, labels, files, or any state. Present the briefing and offe
 digraph status {
     rankdir=LR;
     "Parse scope" [shape=box];
-    "Gather data (6 queries)" [shape=box];
+    "Walk hierarchy" [shape=box];
+    "Enrich nodes" [shape=box];
     "Analyze" [shape=box];
-    "Present briefing" [shape=box];
+    "Present dashboard" [shape=box];
     "Offer next action" [shape=box];
 
-    "Parse scope" -> "Gather data (6 queries)" -> "Analyze" -> "Present briefing" -> "Offer next action";
+    "Parse scope" -> "Walk hierarchy" -> "Enrich nodes" -> "Analyze" -> "Present dashboard" -> "Offer next action";
 }
 ```
 
 ---
 
-This skill is **read-only** — it never modifies issues, labels, files, or any other state. Its sole purpose is situational awareness.
+This skill is **read-only** — it never modifies issues, labels, files, or any other state. It builds a hierarchy tree from the active PI downward, then derives actionable insights from it.
 
 ---
 
 ## Step 1: Determine Scope
 
-Parse `$ARGUMENTS` to determine the query scope:
+Parse `$ARGUMENTS` to determine the display scope:
 
 | Input | Scope |
 |-------|-------|
-| _(empty)_ | Full PI — all stories regardless of area |
-| Area name | Stories with `area:<arg>` label. Read `.claude/sdlc/prd/PRD.md` Label Taxonomy section to discover valid area names. If no PRD exists, treat any argument as a raw `area:<arg>` filter. |
-| `epic #N` | Stories whose body references `Epic: #N` in the `## Parent` section |
+| _(empty)_ | Full PI — all items regardless of area |
+| Area name | Filter display to items with `area:<arg>` label. Read `.claude/sdlc/prd/PRD.md` Label Taxonomy section to discover valid area names. If no PRD exists, treat any argument as a raw `area:<arg>` filter. |
+| `epic #N` | Filter display to a single epic subtree |
 
-Set `AREA_FILTER` accordingly:
-- Full PI: no area filter applied
-- Area filter: append `--label "area:<area>"` to each `gh issue list` command below
-- Epic scope: use text search `--search "Epic: #N in:body"` on the story queries, then also fetch the epic itself with `gh issue view N --json number,title,body,labels,state`
+Set `SCOPE_MODE` accordingly:
+- **Full PI**: no filter applied — display the entire tree
+- **Area filter**: the full tree is still built (so cross-area dependency chains are traced correctly), but only items with the matching `area:<arg>` label and their ancestors are shown in the dashboard
+- **Epic scope**: the hierarchy walk only descends into the specified epic (prune at walk time). For dependency analysis, if a blocker points outside the epic, fetch that issue individually to trace the chain.
 
-If `$ARGUMENTS` is non-empty and does not match the pattern `epic #N`, treat it as an area name. Apply `--label "area:<arg>"` to all queries. If the filter returns no results, announce: "No stories found with label `area:<arg>`. Check the PRD's Label Taxonomy for valid areas, or run with no argument for full PI scope." and stop.
+If `$ARGUMENTS` is non-empty and does not match the pattern `epic #N`, treat it as an area name.
 
 ---
 
-## Step 2: Gather State
+## Step 2: Walk Hierarchy
 
-Run all queries now. Do not skip any — each feeds a different section of the briefing.
+Build the project tree top-down: PI → Epics → Features → Stories.
 
-### 2a. In-Progress Stories
+### 2a. Bulk Fetch
+
+Fetch all issues in two queries to minimize API calls:
 
 ```bash
+# All open issues
 gh issue list \
   --state open \
-  --label "status:in-progress" \
-  --label "type:story" \
-  --json number,title,labels,assignees,createdAt \
-  [--label "area:<area>" if area filter]
-```
+  --json number,title,body,labels,state,assignees,createdAt \
+  --limit 200
 
-### 2b. Blocked Stories
-
-```bash
-gh issue list \
-  --state open \
-  --label "status:blocked" \
-  --label "type:story" \
-  --json number,title,labels,body \
-  [--label "area:<area>" if area filter]
-```
-
-### 2c. Ready Stories (status:todo, unblocked)
-
-```bash
-gh issue list \
-  --state open \
-  --label "status:todo" \
-  --label "type:story" \
-  --json number,title,labels,body \
-  [--label "area:<area>" if area filter]
-```
-
-### 2d. Recently Closed Stories (last 7 days)
-
-Compute the cutoff date (today minus 7 days in ISO 8601 format, e.g. `2026-03-12`), then:
-
-```bash
+# Recently closed issues (for momentum)
 gh issue list \
   --state closed \
-  --label "type:story" \
-  --json number,title,closedAt \
-  --jq '[.[] | select(.closedAt > "YYYY-MM-DD")]' \
-  [--label "area:<area>" if area filter]
+  --json number,title,body,labels,state,closedAt \
+  --limit 100
 ```
 
-Replace `YYYY-MM-DD` with the actual computed cutoff date.
+Build a lookup map keyed by issue number. If the open query returns exactly 200 results, note that some issues may be missing — fall back to individual `gh issue view` for any issue referenced in the hierarchy but not found in the cache.
 
-### 2e. PI Context
+### 2b. Identify Active PI
 
-```bash
-gh issue list --label "type:pi" --state open --json number,title,body --jq '.[0]'
+From the bulk cache, find the issue with a `type:pi` label that is open.
+
+```
+Filter: labels contains "type:pi" AND state == "OPEN"
 ```
 
-If no open PI issue is found, skip this step silently — PI context is supplementary.
+If no open PI issue found: output the "No active PI" dashboard (PI Overview only + stale drafts if any) and skip to Step 5.
 
-### 2f. Stale Drafts
+Parse the PI body's `## Epics` section for epic issue numbers. Match using the format:
+
+```
+### Epic: <name> (#<number>)
+```
+
+Regex: `### Epic: .+ \(#(\d+)\)`
+
+Collect all matched numbers into `EPIC_NUMS`. If an epic subsection has no `(#N)` (e.g., `### Epic: <name>` without a number), log a warning: "Epic '<name>' has no linked issue number — skipping." and skip that entry.
+
+If `SCOPE_MODE` is epic filter, restrict `EPIC_NUMS` to contain only the requested epic number. If that number is not found in the PI body, warn: "Epic #N is not listed in the active PI." but proceed with fetching it directly.
+
+### 2c. Walk Epics → Features
+
+For each epic number in `EPIC_NUMS`, look up the issue from the cache (or fetch via `gh issue view <N> --json number,title,body,labels,state` if not cached).
+
+Parse the epic body's `## Features` section. Feature references use checklist format:
+
+```
+- [ ] <title> (#<number>)
+- [x] <title> (#<number>)
+```
+
+Regex: `- \[[ x]\] .+ \(#(\d+)\)`
+
+Collect feature numbers for this epic. Also scan the epic body for `## Bugs` or `## Chores` sections using the same checklist pattern — include discovered bugs/chores as children of the epic.
+
+### 2d. Walk Features → Stories
+
+For each feature number, look up from cache.
+
+Check the feature's labels for size classification:
+- `size:large` → parse `## Stories` section for story numbers using the same checklist regex
+- `size:small` → the feature itself is a leaf work item, no stories to parse
+- No size label → treat as `size:small` (leaf)
+
+For `size:large` features, also scan for `## Bugs` or `## Chores` sections — include as children.
+
+### 2e. Leaf Nodes (Stories, Bugs, Chores)
+
+For each story/bug/chore number discovered, look up from cache. These are the leaf nodes of the tree. Store: number, title, labels, state, assignees, createdAt, closedAt (if closed), body.
+
+### 2f. Stale Drafts Scan
 
 ```bash
+# All draft files with modification dates
 ls -la .claude/sdlc/drafts/ 2>/dev/null
+
+# Stale drafts (modified more than 7 days ago)
+find .claude/sdlc/drafts/ -type f -mtime +7 2>/dev/null
 ```
 
-If the directory does not exist or is empty, skip this step. Otherwise note each file's name and modification date.
+If the directory does not exist or is empty, skip. Otherwise note each file's name and modification date. Use the `find` output to identify stale drafts directly.
+
+### Edge Cases
+
+- **Missing/deleted issue** — referenced number not in cache AND `gh issue view` returns an error: log "Issue #N referenced in <parent> but not found (deleted or transferred). Skipping." Continue the walk.
+- **PI with no parseable epics** — show PI Overview with `0/0 epics`. Add note: "PI has no epics listed. Run `/sdlc:define epic` to add one."
+- **Epic with no features** — include the epic in the tree with zero children. It will appear in PI Overview counts but not in other sections.
+- **Feature with no stories and no size label** — treat as size:small leaf.
 
 ---
 
-## Step 3: Analyze
+## Step 3: Enrich Nodes
 
-### 3a. In-Progress Analysis
+After the tree is built, compute derived data for each node.
 
-For each in-progress story:
+### 3a. Status Classification
+
+For each node, determine effective status from labels:
+
+| Label | Status |
+|-------|--------|
+| `status:in-progress` | IN_PROGRESS |
+| `status:blocked` | BLOCKED |
+| `status:todo` | TODO |
+| `status:done` OR state=CLOSED | DONE |
+
+Epics and features typically do not carry status labels. For these, **derive status from children** using this precedence (first match wins):
+1. Any child IN_PROGRESS → IN_PROGRESS
+2. Any child TODO (and none in-progress) → TODO (actionable work exists)
+3. All remaining children BLOCKED or DONE (but not all DONE) → BLOCKED
+4. All children DONE → DONE
+
+### 3b. Dependency Extraction
+
+For each node, parse the `## Dependencies` section of the issue body:
+
+- Lines matching `- Blocked by: #N` or `- Blocked by: #N, #M` → extract blocker issue numbers
+- Lines matching `- Blocks: #N` or `- Blocks: #N, #M` → extract blocked issue numbers
+
+Build:
+- `blockers_of[N]` → list of issue numbers that block N
+- `blocks[N]` → list of issue numbers that N blocks
+
+### 3c. Age Calculation
+
+For each IN_PROGRESS item:
 - Calculate age: days since `createdAt` (round to nearest day; show "< 1 day" for same-day)
-- List assignees (show `unassigned` if empty)
-- Flag as **stale** if age > 5 days (mark with `[STALE]`)
+- Flag as **STALE** if age > 5 days
 
-### 3b. Root Blocker Tracing
+Note: Age is calculated from issue creation date, not from when `status:in-progress` was applied. This is an approximation to avoid additional Timeline API calls per issue. For stories that sat in TODO for a long time before starting, the age may appear inflated.
 
-For each blocked story:
+### 3d. Completion Counts
 
-1. Parse `Blocked by:` from the issue body. Extract issue numbers (e.g., `Blocked by: #48, #52` → `[48, 52]`).
+For each parent node (PI, epic, feature), count children by status:
+- `done_count` — children that are DONE
+- `total_count` — total children
+- `in_progress_count`, `blocked_count`, `todo_count` — for derived status
 
-   ```bash
-   gh issue view <blocked-number> --json body \
-     --jq '.body | capture("Blocked by: (?<refs>#[\\d, #]+)") | .refs | split(", ") | map(ltrimstr("#") | tonumber)'
-   ```
+These feed PI Overview and Momentum sections.
 
-2. For each blocker number, check its status:
+---
 
-   ```bash
-   gh issue view <blocker-number> --json number,title,state,labels \
-     --jq '{number, title, state, labels: [.labels[].name]}'
-   ```
+## Step 4: Analyze
 
-3. A blocker is **satisfied** if: `state == "CLOSED"` OR labels contain `"status:done"`.
-   A blocker is **unmet** if: `state == "OPEN"` AND labels do NOT contain `"status:done"`.
+### 4a. Root Blocker Tracing
 
-4. For each **unmet** blocker, repeat steps 1–3 recursively on THAT blocker's `Blocked by` field. Continue until you reach either a satisfied blocker or an issue with no `Blocked by` entry.
+For each BLOCKED node:
 
-5. The **root blocker** is the deepest unmet issue in the chain — the one blocking everything above it. If there are multiple chains, trace each independently.
+1. Extract blocker numbers from `blockers_of[N]`.
+2. For each blocker, check its status: DONE or state=CLOSED → **satisfied**. Otherwise → **unmet**.
+3. For each unmet blocker, recurse: check ITS `blockers_of` and repeat.
+4. Track a `visited` set to detect circular dependencies. If a cycle is found, report: "Circular dependency detected: #A → #B → #A. Run `/sdlc:reconcile` to diagnose." Stop tracing that chain.
+5. The **root blocker** is the deepest unmet issue in the chain.
+6. Count how many items a root blocker transitively unblocks.
 
-6. Count how many blocked stories a root blocker unblocks transitively (to report "unblocks N stories when done").
+**Hierarchy insight** — for each blocked item, check if it is the *last remaining* un-done item under its parent. If so:
+- "Last story in Feature #F — resolving this completes the feature"
+- If the feature completing would also complete the epic: "Gates Feature #F completion, which gates Epic #E"
 
-### 3c. Ready Story Ranking
+Group blocked items by root blocker in the output.
 
-For each ready story, extract the priority label:
-- `priority:critical` → rank 1
-- `priority:high` → rank 2
-- `priority:medium` → rank 3
-- `priority:low` → rank 4
-- _(no priority label)_ → rank 5
+### 4b. Impact Scoring (What's Next ranking)
 
-Sort ready stories by rank ascending (critical first). Within the same rank, preserve the original `gh issue list` order (most recently created first).
+For each TODO item (candidate for What's Next), compute an impact score:
 
-### 3d. Parallelization Analysis
+| Component | Points | Condition |
+|-----------|--------|-----------|
+| Completes feature | 4 | This is the last un-done item under its parent — all siblings are DONE |
+| Unblocks siblings | 3 | This item's number appears in a sibling's `Blocked by` list |
+| Gates parent completion | 2 | Completing this (plus already-done siblings) would complete the parent, AND that parent completing would complete its own parent |
+| Priority weight | 0–1 | critical=1.0, high=0.75, medium=0.5, low=0.25, none=0 |
 
-Two ready stories can run in parallel if they have **no dependency relationship** with each other:
-- Story A does NOT appear in story B's `Blocked by` or `Blocks` fields
-- Story B does NOT appear in story A's `Blocked by` or `Blocks` fields
-- They do not share a common unsatisfied blocker
+**Score** = sum of all applicable component points.
 
-Parse `Blocked by:` and `Blocks:` from each ready story's body. Build a dependency set for each story. Then identify groups of stories with disjoint dependency sets — those can run simultaneously in separate worktrees.
+**Algorithm:**
+1. For each TODO item N, look up its parent P in the tree.
+2. Count how many siblings of N are DONE vs total siblings.
+3. If `(done_siblings + 1) == total_siblings` → "completes feature" = 4 points.
+4. Check if N's number appears in any sibling's `blockers_of` list → "unblocks siblings" = 3 points (also note which siblings).
+5. If "completes feature" is true, check if parent P completing would complete P's parent → "gates parent" = 2 points.
+6. Add priority weight from N's labels.
+7. Sort all TODO items by score descending. Ties broken by priority label rank (critical > high > medium > low > none), then by issue number ascending (older first).
 
-If there are 4+ ready stories, identify the top 2–3 parallelization opportunities rather than listing all combinations.
+### 4c. Parallelization Analysis
 
-### 3e. Stale Draft Detection
+Identify independent work streams at the highest meaningful level.
 
-For each file found in `.claude/sdlc/drafts/`:
+**Level 1 — Epic-level parallelization:**
+1. Group all TODO leaf items by their epic ancestor.
+2. If TODO items exist under 2+ different epics → those are independent streams. Report at epic level.
+
+**Level 2 — Feature-level parallelization (within a single epic):**
+1. Group TODO leaf items by their feature ancestor.
+2. Two features are independent if no TODO item in feature A has a dependency edge (blockers_of or blocks) pointing to any item in feature B.
+3. If independent features found → report at feature level.
+
+**Level 3 — Story-level parallelization (within a single feature):**
+1. Two TODO items are independent if neither appears in the other's `blockers_of` or `blocks` lists, and they share no common unmet blocker.
+2. If independent stories found → report at story level.
+
+Always report at the highest applicable level. If epic-level parallelization exists, do not redundantly list feature-level within those epics.
+
+### 4d. Momentum Calculation
+
+- **Total leaf items in PI**: count all stories + size:small features in the tree (any state).
+- **Done items**: count all leaf nodes with status DONE.
+- **Remaining**: total - done.
+- **Closed in last 7 days**: count leaf nodes where `closedAt` falls within the last 7 calendar days.
+- **Closed in previous 7 days** (days 8–14): count for trend comparison.
+- **Trend**: if `last_7d > prev_7d` → up. If `last_7d < prev_7d` → down. If equal → flat.
+
+### 4e. Stale Draft Detection
+
+For each file in `.claude/sdlc/drafts/`:
 - Parse the modification date from `ls -la` output
 - A draft is **stale** if its modification date is more than 7 days ago
 - Note the filename and age in days
 
-### 3f. Momentum Calculation
+---
 
-- Total PI stories closed: count of all closed `type:story` issues. If PI issue loaded, compare against planned total.
-- Stories closed in last 7 days: count from Step 2d.
-- Stories remaining: in-progress + blocked + ready counts combined.
+## Step 5: Present Dashboard
+
+Load the dashboard template from `${CLAUDE_PLUGIN_ROOT}/skills/status/reference/dashboard-template.md` for reference on the output format.
+
+Populate each section with the analyzed data. Follow these rules:
+
+- **Always show**: PI Overview, Momentum
+- **Omit if zero items**: In Progress, Blocked, What's Next, Parallelization
+- **Omit if no stale drafts**: Stale Drafts callout
+- **Section order is rigid**: PI Overview → In Progress → Momentum → Blocked → What's Next → Parallelization → Stale Drafts
+- **Area filter**: when active, only show items with the matching area label (and their ancestors for context). Dependency analysis in Blocked still traces cross-area chains.
 
 ---
 
-## Step 4: Present Briefing
+## Step 6: Offer Next Action
 
-Output the briefing using this exact format. Omit any section that has zero items (except Momentum — always show it).
+After presenting the dashboard, output exactly:
 
-```
-## Current PI: <PI name from active PI issue, or "No active PI" if not found>
-
-### In Progress (<count>)
-- #<N> <title> (<area>) — <age> [STALE if applicable]
-  Assigned: <assignee login or "unassigned">
-
-### Blocked (<count>)
-- #<N> <title> ← waiting on #<blocker>
-- #<N> <title> ← waiting on #<mid> ← #<root>
-  → Root blocker: #<root-N> <root title> (<status>) — unblocks <X> stories when done
-
-### Ready to Pick Up (<count>, ranked)
-1. #<N> <title> (<area>, <priority>)
-2. #<N> <title> (<area>, <priority>)
-...
-
-### Can Parallelize
-- Worktree A: #<N> (<area>) — <reason it's independent>
-- Worktree B: #<N> or #<N> (<area>) — <reason it's independent>
-
-### Stale Drafts
-- <filename> (<age> days old)
-
-### Momentum
-- <total closed> stories closed this PI, <remaining> remaining
-- <recent count> stories closed in last 7 days
-```
-
-**Example output (for reference — replace with real data):**
-
-```
-## Current PI: PI-1 — MVP Foundation
-
-### In Progress (2)
-- #48 Token encryption (auth) — 2 days
-  Assigned: chakraborty29
-- #55 Chat UI scaffold (ui) — 1 day
-  Assigned: unassigned
-
-### Blocked (3)
-- #52 Session history API ← waiting on #48
-- #60 Calendar tool ← waiting on #52 ← #48
-  → Root blocker: #48 (in progress, unblocks 2 stories when done)
-- #63 Search indexing ← waiting on #61 (not started)
-
-### Ready to Pick Up (4, ranked)
-1. #61 Vector store setup (search, priority:critical)
-2. #57 Error boundary component (ui, priority:high)
-3. #58 Loading states (ui, priority:medium)
-4. #62 Rate limiter middleware (api, priority:medium)
-
-### Can Parallelize
-- Worktree A: #61 (search) — independent of all ui stories
-- Worktree B: #57 or #58 (ui) — no dependency on #61
-
-### Stale Drafts
-- epic-auth.md (12 days old)
-
-### Momentum
-- 8 stories closed this PI, 12 remaining
-- 3 stories closed in last 7 days
-```
-
----
-
-## Step 5: Offer Next Action
-
-After presenting the briefing, output exactly:
-
-> Want to pick up one of these? I can start implementation or run `/sdlc:define story` if a ready story needs more detail before starting.
+> Want to pick up one of these? I can start implementation or run `/sdlc:define story` if a ready item needs more detail first.
 
 Do not ask follow-up questions or take any action. This skill is read-only — the user decides what to do next.
 
@@ -281,19 +309,22 @@ Do not ask follow-up questions or take any action. This skill is read-only — t
 Before finishing, verify ALL steps were completed:
 
 - [ ] Step 1: Scope determined from `$ARGUMENTS`
-- [ ] Step 2a: In-progress stories fetched
-- [ ] Step 2b: Blocked stories fetched
-- [ ] Step 2c: Ready stories fetched
-- [ ] Step 2d: Recently closed stories fetched
-- [ ] Step 2e: Active PI issue fetched (or skipped if not found)
-- [ ] Step 2f: Drafts directory scanned (or skipped if missing)
-- [ ] Step 3a: In-progress age and stale flag computed
-- [ ] Step 3b: Root blockers traced (not just immediate blockers)
-- [ ] Step 3c: Ready stories ranked by priority
-- [ ] Step 3d: Parallelization opportunities identified
-- [ ] Step 3e: Stale drafts identified
-- [ ] Step 3f: Momentum numbers computed
-- [ ] Step 4: Briefing presented in the specified format
-- [ ] Step 5: Next action offer output
+- [ ] Step 2a: Bulk fetch of open and closed issues completed
+- [ ] Step 2b: Active PI identified and epic numbers parsed from body
+- [ ] Step 2c: Each epic fetched and features parsed
+- [ ] Step 2d: Each feature fetched, size checked, stories parsed (or noted as leaf)
+- [ ] Step 2e: Each story/bug/chore leaf node fetched
+- [ ] Step 2f: Stale drafts directory scanned (or skipped if missing)
+- [ ] Step 3a: Status classification applied to all nodes (derived for parents)
+- [ ] Step 3b: Dependencies extracted from all node bodies
+- [ ] Step 3c: Age calculated for in-progress items, STALE flags set
+- [ ] Step 3d: Completion counts computed for all parent nodes
+- [ ] Step 4a: Root blockers traced recursively with hierarchy insights
+- [ ] Step 4b: Impact scores computed for all TODO items
+- [ ] Step 4c: Parallelization analyzed at epic > feature > story level
+- [ ] Step 4d: Momentum calculated with 7-day trend
+- [ ] Step 4e: Stale drafts flagged (>7 days)
+- [ ] Step 5: Dashboard presented following reference template section order
+- [ ] Step 6: Next action offer output
 
 If any step was skipped without a documented skip condition, go back and complete it now.

--- a/.claude/plugins/sdlc/skills/status/reference/dashboard-template.md
+++ b/.claude/plugins/sdlc/skills/status/reference/dashboard-template.md
@@ -1,0 +1,179 @@
+# Dashboard Template
+
+The canonical output format for the sdlc:status dashboard. Populate each section with real data. Omit sections with zero items except PI Overview and Momentum (always show).
+
+## Section Order
+
+1. PI Overview (always show)
+2. In Progress (omit if zero)
+3. Momentum (always show)
+4. Blocked (omit if zero)
+5. What's Next (omit if zero)
+6. Parallelization (omit if zero)
+7. Stale Drafts (minor callout, omit if none)
+
+---
+
+## PI Overview
+
+Always show. This is the context frame for the entire dashboard.
+
+```
+## <PI title> (#N)
+
+> <done_epics>/<total_epics> epics complete | <done_features>/<total_features> features | <done_stories>/<total_stories> stories
+```
+
+If scope filter is active, append: `(filtered: area:<name>)` or `(filtered: epic #N)`
+
+If no active PI found:
+
+```
+## No active PI
+
+> Run `/sdlc:define pi` to plan an increment.
+```
+
+---
+
+## In Progress
+
+Show items with `status:in-progress` label (stories and size:small features). Table format with parent context.
+
+```
+### In Progress (<count>)
+
+| # | Title | Parent | Area | Age | Assignee |
+|---|-------|--------|------|-----|----------|
+| #N | <title> | Feature #F > Epic #E | area:X | N days | @user |
+| #N | <title> | Feature #F > Epic #E | area:X | N days [STALE] | unassigned |
+```
+
+- Sort by age descending (oldest first)
+- Mark `[STALE]` if age > 5 days
+- Parent column shows the item's place in the hierarchy: `Feature #F > Epic #E`
+- For size:small features (no parent feature), show: `Epic #E`
+- Include both stories and size:small features that are in-progress
+
+---
+
+## Momentum
+
+Always show. Provides velocity context before showing blockers.
+
+```
+### Momentum
+
+- **<done_total>** / **<planned_total>** items closed this PI (<percentage>%)
+- **<closed_7d>** closed in last 7 days <trend_arrow> (was <closed_prev_7d> previous week)
+```
+
+Trend arrows:
+- More than previous week: arrow up
+- Fewer than previous week: arrow down
+- Same: flat/steady
+
+---
+
+## Blocked
+
+Show items with `status:blocked` label. Trace blocker chains recursively and add hierarchy insights.
+
+```
+### Blocked (<count>)
+
+**Root blocker: #R <root title> (<root status>)** — unblocks <X> items when resolved
+
+- #N <title> (Feature #F > Epic #E)
+  Blocked by: #B <blocker title> (<blocker status>)
+  <hierarchy insight>
+
+- #M <title> (Feature #F > Epic #E)
+  Blocked by: #B2 -> #R (chain)
+  <hierarchy insight>
+```
+
+- Group blocked items by their root blocker
+- Show the full blocker chain when it has intermediate links: `#B -> #R`
+- Hierarchy insights explain the impact in context:
+  - "Last story in Feature #F — resolving this completes the feature"
+  - "Blocks 2 siblings in Feature #F"
+  - "Gates Feature #F completion, which gates Epic #E"
+
+---
+
+## What's Next
+
+Show TODO items ranked by impact score, not just priority. This is the primary action recommendation.
+
+```
+### What's Next (<count>, ranked by impact)
+
+1. **#N <title>** (area:X, priority:Y) — score: <S>
+   Feature #F > Epic #E
+   Impact: <reason>
+
+2. **#N <title>** (area:X, priority:Y) — score: <S>
+   Feature #F > Epic #E
+   Impact: <reason>
+```
+
+Impact scoring components:
+| Component | Points | Condition |
+|-----------|--------|-----------|
+| Completes feature | 4 | Last un-done item under its parent feature |
+| Unblocks siblings | 3 | Appears in a sibling's `Blocked by` list |
+| Gates parent completion | 2 | Completing this + done siblings completes parent, which completes grandparent |
+| Priority weight | 0-1 | critical=1.0, high=0.75, medium=0.5, low=0.25 |
+
+Score = sum of applicable components. Ties broken by priority label, then issue number ascending.
+
+Impact reason examples:
+- "Last story in Feature #F — completes the feature"
+- "Unblocks #A, #B (sibling stories)"
+- "Gates Feature #F which gates Epic #E"
+- "High priority, no blocking impact"
+
+---
+
+## Parallelization
+
+Identify independent work streams at the highest meaningful level. Adjacent to What's Next — together they form the action block.
+
+```
+### Parallelization
+
+**Stream A: Epic #E1 — <epic title>**
+- Available: #N <story>, #M <story>
+- Independent: no shared blockers with Stream B
+
+**Stream B: Epic #E2 — <epic title>**
+- Available: #N <story>
+- Independent: different epic, separate dependency chain
+```
+
+Within a single epic, surface feature-level parallelization:
+
+```
+**Stream A: Feature #F1 — <title> (Epic #E)**
+- Available: #N <story>
+
+**Stream B: Feature #F2 — <title> (Epic #E)**
+- Available: #M <story>
+- Independent: no cross-feature dependencies
+```
+
+Detection hierarchy:
+1. Different epics with TODO items = epic-level streams (strongest signal)
+2. Different features within same epic, no cross-deps = feature-level streams
+3. Same feature, no mutual deps = story-level streams (fallback)
+
+---
+
+## Stale Drafts
+
+Minor callout. Single blockquote line. Only show if stale drafts exist (>7 days old).
+
+```
+> **Stale drafts:** <filename> (<age> days), <filename> (<age> days)
+```


### PR DESCRIPTION
## Summary

- Rewrites the status skill from a flat label-query approach to a **top-down hierarchy walk** (PI → Epics → Features → Stories) that builds a complete project tree
- Adds **impact-ranked What's Next** section with 4-component scoring (completes feature, unblocks siblings, gates parent, priority weight)
- Elevates **parallelization detection** from story-level to epic > feature > story level
- Adds **hierarchy-aware blocker tracing** with context like "Last story in Feature #F — resolving this completes the feature"
- Creates a new **dashboard template** (`skills/status/reference/dashboard-template.md`) defining the rigid output format

## Files Changed

| Action | File |
|--------|------|
| Created | `.claude/plugins/sdlc/skills/status/reference/dashboard-template.md` |
| Rewritten | `.claude/plugins/sdlc/skills/status/SKILL.md` |

## Test plan

- [ ] Run `/sdlc:status` with no arguments — verify full PI hierarchy walk and dashboard output
- [ ] Run `/sdlc:status skills` — verify area filtering shows only `area:skills` items with ancestors
- [ ] Run `/sdlc:status epic #1` — verify epic scope filtering
- [ ] Verify section order: PI Overview → In Progress → Momentum → Blocked → What's Next → Parallelization
- [ ] Verify impact scoring ranks stories gating feature completion higher than isolated stories
- [ ] Verify parallelization identifies epic-level and feature-level independent streams

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)