### PR TITLE
fix(finish-dev): remove worktree gate and flip input to issue number

### DIFF
--- a/.claude/plugins/sdlc/skills/finish-dev/SKILL.md
+++ b/.claude/plugins/sdlc/skills/finish-dev/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: finish-dev
-description: Close out a roll-up branch by creating a PR to its parent branch. Use when all child work items under a large feature, epic, or PI are complete and the branch is ready to merge up.
+description: Create a PR to merge an issue's branch into its parent branch. Use when development on an issue is complete.
 ---
 
 # Finish Dev
 
-Close out a roll-up branch by creating a PR to merge it into its parent branch.
+Create a PR to merge an issue's branch into its parent branch.
 
 <HARD-GATE>
-Do NOT create a PR if any child issues are still open. Do NOT modify issues or labels. This skill only creates a PR.
+Do NOT modify issues or labels. This skill only creates a PR.
 </HARD-GATE>
 
 ## Process Flow
@@ -16,27 +16,21 @@ Do NOT create a PR if any child issues are still open. Do NOT modify issues or l
 ```dot
 digraph finish_dev {
     rankdir=TB;
-    "Worktree gate" [shape=box];
-    "Parse branch name" [shape=box];
-    "Fetch issue + validate" [shape=box];
-    "Eligible?" [shape=diamond];
-    "Abort" [shape=box];
-    "Check children closed" [shape=box];
-    "All closed?" [shape=diamond];
-    "Abort (list open)" [shape=box];
+    "Parse argument" [shape=box];
+    "Resolve branch from issue" [shape=box];
+    "Branch found?" [shape=diamond];
+    "Abort (no branch)" [shape=box];
+    "Fetch issue metadata" [shape=box];
     "Resolve target branch" [shape=box];
     "Generate PR content" [shape=box];
     "Create PR" [shape=box];
     "Report" [shape=box];
 
-    "Worktree gate" -> "Parse branch name";
-    "Parse branch name" -> "Fetch issue + validate";
-    "Fetch issue + validate" -> "Eligible?";
-    "Eligible?" -> "Abort" [label="no"];
-    "Eligible?" -> "Check children closed" [label="yes"];
-    "Check children closed" -> "All closed?";
-    "All closed?" -> "Abort (list open)" [label="no"];
-    "All closed?" -> "Resolve target branch" [label="yes"];
+    "Parse argument" -> "Resolve branch from issue";
+    "Resolve branch from issue" -> "Branch found?";
+    "Branch found?" -> "Abort (no branch)" [label="no"];
+    "Branch found?" -> "Fetch issue metadata" [label="yes"];
+    "Fetch issue metadata" -> "Resolve target branch";
     "Resolve target branch" -> "Generate PR content";
     "Generate PR content" -> "Create PR";
     "Create PR" -> "Report";
@@ -45,41 +39,25 @@ digraph finish_dev {
 
 ---
 
-## Step 1: Worktree Gate
+## Step 1: Parse Argument
 
-Verify this is a git worktree, not the main checkout:
+Extract the issue number from `$ARGUMENTS`. Expected format: `#42` or `42`.
 
-```bash
-GIT_DIR=$(git rev-parse --git-dir)
-GIT_COMMON=$(git rev-parse --git-common-dir)
-test "$GIT_DIR" != "$GIT_COMMON"
-```
+If no issue number is provided, **abort** with:
 
-This works from any subdirectory within the worktree.
+> "Usage: `/sdlc:finish-dev #<issue-number>`"
 
-If the test fails (values are equal), this is the main checkout. **Abort** with:
-
-> "This skill requires a git worktree. Start one with `claude -w` and try again."
-
-## Step 2: Parse Current Branch Name
-
-Extract the level and issue number from the current branch:
+## Step 2: Resolve Branch from Issue
 
 ```bash
-CURRENT_BRANCH=$(git branch --show-current)
+gh issue develop <ISSUE_NUM> --list
 ```
 
-Parse with regex pattern: `^(pi|epic|feature)/(\d+)-(.+)$`
+- **No branch found** → abort: "Issue #`<ISSUE_NUM>` has no linked branch. Nothing to close out."
+- **Exactly one branch** → store as `BRANCH_NAME`
+- **Multiple branches** → present the list and ask the user to pick one. Store selection as `BRANCH_NAME`.
 
-Extract:
-- `LEVEL` from capture group 1
-- `ISSUE_NUM` from capture group 2
-
-If the branch name does not match the pattern, **abort** with:
-
-> "Current branch `<CURRENT_BRANCH>` does not follow the `<level>/<number>-<slug>` convention. This skill only works on branches created by setup-dev."
-
-## Step 3: Fetch Issue and Validate Eligibility
+## Step 3: Fetch Issue Metadata
 
 ```bash
 gh issue view <ISSUE_NUM> --json title,labels,body,state
@@ -87,109 +65,72 @@ gh issue view <ISSUE_NUM> --json title,labels,body,state
 
 Extract:
 - `ISSUE_TITLE` from the title
-- `ISSUE_STATE` from state
-- Labels list
+- `LEVEL` from the `type:*` label (`type:epic` → `epic`, `type:feature` → `feature`, `type:story` → `story`, `type:bug` → `bug`, `type:chore` → `chore`). If no `type:*` label is found, default to `feat`.
+- `ISSUE_BODY` from the body
 
-**Eligibility gate — only the following are allowed:**
+**Gather children (for PR body only — not a gate):**
 
-| Level | Requirement |
-|-------|------------|
-| `feature` | Must have `size:large` label |
-| `epic` | Always eligible |
-| `pi` | Always eligible |
+Based on level, check for a child section in the issue body:
 
-**Reject with clear messages:**
+| Level | Section to parse |
+|-------|-----------------|
+| `feature` | `## Stories` |
+| `epic` | `## Features` |
 
-- If level is `feature` but `size:large` is not present:
-  > "Feature #`<ISSUE_NUM>` is `size:small` — small features don't use roll-up branches. Close this feature's PR directly."
+If a matching section exists, extract issue numbers (`#N`) from checklist items. Store as `CHILDREN` for use in Step 5. If no section or no issue numbers found, `CHILDREN` is empty — this is fine, proceed normally.
 
-- If level is `story`, `bug`, or `chore` (shouldn't match the branch regex, but guard anyway):
-  > "`finish-dev` is for roll-up branches only (large features, epics, PIs). Stories, bugs, and chores should have their PRs merged directly."
-
-## Step 4: Check Child Completion (Hard Block)
-
-Determine the child section and expected child type based on level:
-
-| Level | Section to parse | Child type |
-|-------|-----------------|------------|
-| `feature` (large) | `## Stories` | story |
-| `epic` | `## Features` | feature |
-| `pi` | `## Epics` | epic |
-
-Parse the appropriate section from the issue body. Extract issue numbers from checklist items — the format is `- [ ] <text> (#N)` or `- [x] <text> (#N)` or variations with `#N` anywhere in the line. Extract all `#N` values using a regex like `#(\d+)`.
-
-For each extracted child issue number, verify it is closed:
-
-```bash
-gh issue view <CHILD_NUM> --json state --jq '.state'
-```
-
-**If ANY child issue is not `CLOSED`, abort with:**
-
-> "Cannot create PR — the following child issues are still open:
-> - #X — \<title\> (OPEN)
-> - #Y — \<title\> (OPEN)
->
-> Close all child issues before running finish-dev."
-
-**If the section is empty or no issue numbers are found, abort with:**
-
-> "No child issues found in the `## <Section>` section of #`<ISSUE_NUM>`. Verify the issue body has a properly formatted checklist."
-
-Store the list of child issue numbers and titles as `CHILDREN` for use in Step 6.
-
-## Step 5: Resolve Target Branch
-
-**For PI level:** target branch is always `main`. Skip parent resolution entirely.
-
-**For epic and feature levels:**
+## Step 4: Resolve Target Branch
 
 **Phase 1: Parse `## Parent` section.** Extract from the issue body, checking fields in priority order:
-1. `Epic: #N` → candidate = N (for features)
-2. `PI: #N` → candidate = N (for epics)
+1. `Feature: #N` → candidate = N
+2. `Epic: #N` → candidate = N
+3. `PI: #N` → candidate = N
 
 First match wins. Set `PARENT_ISSUE` to the extracted number.
 
 **Phase 2: Resolve parent's branch.**
 
+If a `PARENT_ISSUE` was found:
+
 ```bash
 gh issue develop <PARENT_ISSUE> --list
 ```
 
-- **No branch found and parent is a PI issue:** `TARGET_BRANCH=main`
-- **No branch found (non-PI parent):** Prompt the user:
+- **No branch found:** Prompt the user:
   > "Parent #N has no linked branch. Provide a target branch name, or press enter to target `main`."
-- **Exactly one branch:** `TARGET_BRANCH=<that branch>` — use it automatically, no prompt needed.
+- **Exactly one branch:** `TARGET_BRANCH=<that branch>` — use it automatically.
 - **Multiple branches:** Present the list and ask the user to pick one.
 
 **If no `## Parent` section found:** Prompt the user:
 > "No parent found in issue #`<ISSUE_NUM>`. Provide a target branch name, or press enter to target `main`."
 
-## Step 6: Generate PR Content
+## Step 5: Generate PR Content
 
 Load the reference template from `${CLAUDE_PLUGIN_ROOT}/skills/finish-dev/reference/pr-template.md` for structural guidance.
 
 **PR Title:**
 
 Conventional format based on level:
-- Feature: `feat(#N): <slugified-issue-title>`
-- Epic: `epic(#N): <slugified-issue-title>`
-- PI: `pi(#N): <slugified-issue-title>`
+- `feature` → `feat(#N): <slugified-issue-title>`
+- `epic` → `epic(#N): <slugified-issue-title>`
+- `story` → `feat(#N): <slugified-issue-title>`
+- `bug` → `fix(#N): <slugified-issue-title>`
+- `chore` → `chore(#N): <slugified-issue-title>`
 
-The slug comes from the **issue title** (not the branch slug). Lowercase, spaces to hyphens, strip special characters.
+The slug comes from the **issue title**. Lowercase, spaces to hyphens, strip special characters.
 
 **PR Body:**
 
 Populate the template with real content:
 
-1. **Summary section:** 1-2 sentence overview of what this branch delivers as an aggregate.
+1. **Summary section:** 1-2 sentence overview of what this branch delivers.
 
-2. **Child Issues table:** List every child issue from `CHILDREN` (gathered in Step 4) with issue number and title.
+2. **Child Issues table** (if `CHILDREN` is non-empty): List every child issue with issue number and title.
 
 3. **Test Plan section:** This is NOT template-based. Read the following context and synthesize a substantive, specific verification plan:
-   - The PR diff: `git diff <TARGET_BRANCH>...HEAD`
+   - The PR diff: `git diff <TARGET_BRANCH>...<BRANCH_NAME>`
    - The current issue body (description, acceptance criteria)
-   - Each child issue's title and description
+   - Child issue titles and descriptions (if any)
 
    The test plan should include:
    - Functional verification steps tied to acceptance criteria
@@ -199,10 +140,11 @@ Populate the template with real content:
 
 4. **Closes footer:** `Closes #<ISSUE_NUM>`
 
-## Step 7: Create PR
+## Step 6: Create PR
 
 ```bash
 gh pr create \
+  --head <BRANCH_NAME> \
   --base <TARGET_BRANCH> \
   --title "<PR_TITLE>" \
   --body "<PR_BODY>"
@@ -214,15 +156,14 @@ gh pr create \
 
 Store the resulting PR URL as `PR_URL`.
 
-## Step 8: Report
+## Step 7: Report
 
 Display to the user:
 
 > **PR Created:**
 > - PR: \<PR_URL\>
-> - Branch: `<CURRENT_BRANCH>` → `<TARGET_BRANCH>`
+> - Branch: `<BRANCH_NAME>` → `<TARGET_BRANCH>`
 > - Issue: #\<ISSUE_NUM\> — "\<ISSUE_TITLE\>"
-> - Children merged: \<count\> \<child-type\>(s)
 >
 > The PR will close #\<ISSUE_NUM\> when merged.
 
@@ -230,11 +171,10 @@ Display to the user:
 
 ## Execution Checklist
 
-- [ ] Step 1: Worktree verified
-- [ ] Step 2: Branch name parsed (level=`<LEVEL>`, issue=`<ISSUE_NUM>`)
-- [ ] Step 3: Issue fetched and eligibility validated
-- [ ] Step 4: All child issues verified CLOSED
-- [ ] Step 5: Target branch resolved
-- [ ] Step 6: PR title, body, and test plan generated
-- [ ] Step 7: PR created via `gh pr create`
-- [ ] Step 8: Summary reported
+- [ ] Step 1: Issue number parsed from arguments
+- [ ] Step 2: Linked branch resolved
+- [ ] Step 3: Issue metadata fetched, children gathered (if any)
+- [ ] Step 4: Target branch resolved
+- [ ] Step 5: PR title, body, and test plan generated
+- [ ] Step 6: PR created via `gh pr create`
+- [ ] Step 7: Summary reported

--- a/.claude/plugins/sdlc/skills/finish-dev/reference/pr-template.md
+++ b/.claude/plugins/sdlc/skills/finish-dev/reference/pr-template.md
@@ -1,6 +1,6 @@
 # PR Body Template
 
-Reference template for finish-dev PR bodies. Claude populates each section with real content — do not use placeholder text.
+Reference template for finish-dev PR bodies. Claude populates each section with real content — do not use placeholder text. The Child Issues section is only included when the issue has children.
 
 ## Structure
 
@@ -37,8 +37,8 @@ Closes #<ISSUE_NUM>
 ### Summary
 Describe the aggregate outcome — what does merging this branch deliver? Do not list individual child PRs. Focus on the capability or milestone this completes.
 
-### Child Issues
-List every child issue from the parent's checklist section (`## Stories` for large features, `## Features` for epics, `## Epics` for PIs). Include issue number and title for each.
+### Child Issues (conditional)
+Only include this section if the issue has child issues listed in its body (`## Stories` for features, `## Features` for epics). Include issue number and title for each. Omit the entire section for issues without children (stories, bugs, chores).
 
 ### Test Plan
 Read the actual diff and issue context. Include:


### PR DESCRIPTION
## Summary

Rewrites the finish-dev skill to accept an issue number as input instead of deriving it from the current branch name. Removes the worktree gate, eligibility gate, and child-completion hard block — the skill now goes straight from issue number to PR creation.

- Flips input flow: issue # → branch lookup (via `gh issue develop --list`) instead of branch → issue
- Drops worktree requirement, eligibility check (large features/epics/PIs only), and child-completion block
- Extends PR title format to all issue types (story, bug, chore)
- Keeps parent/target branch resolution, PR content generation with diff analysis, and test plan synthesis
- Updates pr-template.md to mark child issues section as conditional

## Test plan

- [ ] Run `/sdlc:finish-dev 49` — should resolve linked branch and create PR
- [ ] Run `/sdlc:finish-dev` with no argument — should abort with usage message
- [ ] Run with an issue that has no linked branch — should abort with clear message
- [ ] Run with an issue that has a `## Parent` section — should auto-resolve target branch
- [ ] Run with an issue missing parent — should prompt for target branch

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)