### PR TITLE
feat(#60): add-technical-notes-to-epic-template-and-propagation-chain

### DIFF
--- a/.claude/plugins/sdlc/agents/create-agent/reference/epic-execution.md
+++ b/.claude/plugins/sdlc/agents/create-agent/reference/epic-execution.md
@@ -13,7 +13,7 @@
 - `## Success Criteria` — at least one checkbox item
 - `## Features` — at least one checklist item with `(#TBD)` placeholder
 
-Additional sections (Non-goals, Dependencies) are expected but not blocking.
+Additional sections (Non-goals, Technical Notes, Dependencies) are expected but not blocking.
 
 ## Execution Steps
 

--- a/.claude/plugins/sdlc/agents/create-agent/reference/feature-execution.md
+++ b/.claude/plugins/sdlc/agents/create-agent/reference/feature-execution.md
@@ -13,7 +13,7 @@
 - `## Description` — non-empty
 - `## Stories` — **only if `size: large`**: at least one checklist item with `(#TBD)` placeholder. **Must NOT exist if `size: small`.**
 
-Additional sections (Non-goals, Dependencies, Parent) are expected but not blocking.
+Additional sections (Non-goals, Technical Notes, File Scope, Dependencies, Parent) are expected but not blocking.
 
 ## Execution Steps
 

--- a/.claude/plugins/sdlc/skills/define/reference/epic-brainstorm.md
+++ b/.claude/plugins/sdlc/skills/define/reference/epic-brainstorm.md
@@ -10,6 +10,7 @@ Internal checklist for the define skill. Weave these into natural conversation â
 - What's the priority relative to other epics?
 - Any dependencies on other epics?
 - What areas of the codebase does this touch?
+- What architectural decisions, cross-cutting constraints, or technical approach should child features build on?
 
 ## Context to load
 

--- a/.claude/plugins/sdlc/skills/define/reference/feature-brainstorm.md
+++ b/.claude/plugins/sdlc/skills/define/reference/feature-brainstorm.md
@@ -16,7 +16,7 @@ Internal checklist for the define skill. Weave these into natural conversation �
 
 ## Context to load
 
-- Read the parent epic: `gh issue view <parent-epic> --json title,body,labels`
+- Read the parent epic: `gh issue view <parent-epic> --json title,body,labels` — review its Technical Notes section for architectural decisions and constraints to build on
 - Read active PI issue (`gh issue list --label "type:pi" --state open`) — check if this feature was listed as a scope seed
 - Read `.claude/sdlc/prd/PRD.md` — check relevant Architecture and Data Models sections
 

--- a/.claude/plugins/sdlc/templates/epic-template.md
+++ b/.claude/plugins/sdlc/templates/epic-template.md
@@ -21,5 +21,6 @@ status: draft
 - `## Success Criteria` — Checklist of measurable conditions for "done"
 - `## Features` — Checklist of features with `(#TBD)` placeholders for issue numbers
 - `## Non-goals` — Explicit exclusions
+- `## Technical Notes` — Architectural decisions, cross-cutting constraints, and technical approach that child features should build on
 - `## Dependencies` — Bidirectional format: `- Blocked by: #N` / `- Blocks: #N` (or `none`)
 - `## Parent` — `PI: #<N>` (links to parent PI issue)

--- a/.claude/sdlc/prd/PRD.md
+++ b/.claude/sdlc/prd/PRD.md
@@ -60,8 +60,8 @@ PRD (git: .claude/sdlc/prd/PRD.md)
 |----------|---------|-----------|
 | PRD | `.claude/sdlc/prd/PRD.md` (git) | name, version, created, Overview, Tech Stack, Architecture, Data Models, API Contracts, Security Constraints, Roadmap, Acceptance Criteria, Out of Scope, Label Taxonomy, Decision Log |
 | PI | GitHub Issue (`type:pi`) | name, theme, Timeline (started, target), Goals, Epics (with scope seeds and #TBD placeholders), Dependencies, Worktree Strategy |
-| Epic | GitHub Issue (`type:epic`) | title, Overview, Success Criteria, Features checklist, Non-goals, Dependencies |
-| Feature | GitHub Issue (`type:feature`) | title, Description, size (small/large), Acceptance Criteria, Stories checklist (if size:large), Non-goals, Dependencies, Parent Epic link |
+| Epic | GitHub Issue (`type:epic`) | title, Overview, Success Criteria, Features checklist, Non-goals, Technical Notes, Dependencies |
+| Feature | GitHub Issue (`type:feature`) | title, Description, size (small/large), Acceptance Criteria, Stories checklist (if size:large), Non-goals, Technical Notes, Dependencies, Parent Epic link |
 | Story | GitHub Issue (`type:story`) | title, Description, Acceptance Criteria, File Scope, Technical Notes, Dependencies, Parent Epic + Feature links |
 
 ### Label Taxonomy


### PR DESCRIPTION
## Summary

Adds `## Technical Notes` to the epic template and establishes the propagation chain so architectural decisions captured during epic brainstorming flow into child feature definitions. Also fixes a pre-existing gap in the feature execution reference and PRD Data Models table.

## Test Plan

- [ ] **Epic template section order**: Verify `epic-template.md` lists Technical Notes between Non-goals and Dependencies in the Required Sections bullets
- [ ] **Epic template description**: Confirm the Technical Notes description reads "Architectural decisions, cross-cutting constraints, and technical approach that child features should build on" — distinct from the feature template's "Implementation considerations, patterns, architectural decisions"
- [ ] **Epic brainstorm coverage**: Verify `epic-brainstorm.md` includes the new checklist item about architectural decisions/cross-cutting constraints, framed at the architectural level (not implementation-level like the feature brainstorm)
- [ ] **Epic execution validation**: Confirm `epic-execution.md` "expected but not blocking" sentence now lists Non-goals, Technical Notes, Dependencies (in that order)
- [ ] **Feature brainstorm propagation**: Verify `feature-brainstorm.md` Context to load section now explicitly instructs reviewing the parent epic's Technical Notes when loading the parent epic issue
- [ ] **Feature execution completeness**: Confirm `feature-execution.md` "expected but not blocking" sentence includes Technical Notes and File Scope alongside Non-goals, Dependencies, and Parent
- [ ] **PRD Epic row**: Verify the Data Models Artifact Types table Epic row includes Technical Notes in Key Fields, positioned between Non-goals and Dependencies
- [ ] **PRD Feature row (bonus fix)**: Verify the Feature row also now includes Technical Notes in Key Fields (pre-existing gap fixed alongside the Epic row)
- [ ] **Cross-level consistency**: Technical Notes appears between Non-goals and Dependencies in every file where section ordering is implied (template, execution reference, PRD table)

---

Closes #60