### PR TITLE
feat(#62): fix-temp-file-collision-in-parallel-agent-execution

### DIFF
--- a/.claude/plugins/sdlc/agents/create-agent/reference/epic-execution.md
+++ b/.claude/plugins/sdlc/agents/create-agent/reference/epic-execution.md
@@ -23,19 +23,22 @@ If dispatched with `stub: true`, skip Step 2 (Create and Link Branch). All other
 
 ### 1. Create the Epic Issue
 
-Write the draft body (without YAML frontmatter) to a temp file and create the issue:
+Write the draft body (without YAML frontmatter) to a temp file and create the issue.
+
+Slugify the epic name for the temp file path — lowercase, replace non-alphanumeric characters with hyphens, collapse consecutive hyphens, strip leading/trailing hyphens.
 
 ```bash
 # Strip frontmatter from draft, write body to temp file
 # (everything after the closing --- of the frontmatter)
+# SLUG = slugified <name> (e.g., "User Authentication" -> "user-authentication")
 
-cat <<'BODY' > /tmp/sdlc-epic-body.md
+cat <<'BODY' > /tmp/sdlc-epic-<SLUG>-body.md
 <draft body content without frontmatter>
 BODY
 
 EPIC_URL=$(gh issue create \
   --title "<name>" \
-  --body-file /tmp/sdlc-epic-body.md \
+  --body-file /tmp/sdlc-epic-<SLUG>-body.md \
   --label "type:epic" \
   --label "priority:<priority>" \
   --label "area:<area1>" \
@@ -85,7 +88,7 @@ gh issue edit <parent-pi> --body "$UPDATED_BODY"
 ### 5. Clean Up Temp Files
 
 ```bash
-rm -f /tmp/sdlc-epic-body.md
+rm -f /tmp/sdlc-epic-<SLUG>-body.md
 ```
 
 ## Report Format

--- a/.claude/plugins/sdlc/agents/create-agent/reference/feature-execution.md
+++ b/.claude/plugins/sdlc/agents/create-agent/reference/feature-execution.md
@@ -23,16 +23,20 @@ If dispatched with `stub: true`, skip Step 2 (Create and Link Branch). All other
 
 ### 1. Create the Feature Issue
 
-Write the draft body (without YAML frontmatter) to a temp file and create the issue:
+Write the draft body (without YAML frontmatter) to a temp file and create the issue.
+
+Slugify the feature name for the temp file path — lowercase, replace non-alphanumeric characters with hyphens, collapse consecutive hyphens, strip leading/trailing hyphens.
 
 ```bash
-cat <<'BODY' > /tmp/sdlc-feature-body.md
+# SLUG = slugified <name> (e.g., "Execution Reliability" -> "execution-reliability")
+
+cat <<'BODY' > /tmp/sdlc-feature-<SLUG>-body.md
 <draft body content without frontmatter>
 BODY
 
 FEAT_URL=$(gh issue create \
   --title "<name>" \
-  --body-file /tmp/sdlc-feature-body.md \
+  --body-file /tmp/sdlc-feature-<SLUG>-body.md \
   --label "type:feature" \
   --label "priority:<priority>" \
   --label "size:<size>" \
@@ -87,7 +91,7 @@ echo "$UPDATED_BLOCKER_BODY" | gh issue edit <N> --body-file -
 ### 5. Clean Up Temp Files
 
 ```bash
-rm -f /tmp/sdlc-feature-body.md
+rm -f /tmp/sdlc-feature-<SLUG>-body.md
 ```
 
 ## Report Format

--- a/.claude/plugins/sdlc/agents/create-agent/reference/pi-execution.md
+++ b/.claude/plugins/sdlc/agents/create-agent/reference/pi-execution.md
@@ -35,26 +35,29 @@ gh issue close <ACTIVE_PI_NUM>
 
 ### 3. Create the PI Issue
 
-Strip the YAML frontmatter from the draft and write the body to a temp file, then create the issue:
+Strip the YAML frontmatter from the draft and write the body to a temp file, then create the issue.
+
+Slugify the PI name for the temp file path — lowercase, replace non-alphanumeric characters with hyphens, collapse consecutive hyphens, strip leading/trailing hyphens.
 
 ```bash
 # Strip frontmatter from draft, write body to temp file
 # (everything after the closing --- of the frontmatter)
+# SLUG = slugified <name> (e.g., "PI-2: Core Platform" -> "pi-2-core-platform")
 
-cat <<'BODY' > /tmp/sdlc-pi-body.md
+cat <<'BODY' > /tmp/sdlc-pi-<SLUG>-body.md
 <draft body content without frontmatter>
 BODY
 
 PI_URL=$(gh issue create \
   --title "<name>" \
-  --body-file /tmp/sdlc-pi-body.md \
+  --body-file /tmp/sdlc-pi-<SLUG>-body.md \
   --label "type:pi" \
   --label "priority:<priority>" \
   --label "area:<area1>" \
   --label "area:<area2>")
 PI_NUM=$(echo "$PI_URL" | grep -o '[0-9]*$')
 
-rm -f /tmp/sdlc-pi-body.md
+rm -f /tmp/sdlc-pi-<SLUG>-body.md
 ```
 
 **Note:** Do NOT add a `status:` label to PI issues. Status labels are for stories only.

--- a/.claude/plugins/sdlc/agents/create-agent/reference/story-execution.md
+++ b/.claude/plugins/sdlc/agents/create-agent/reference/story-execution.md
@@ -40,16 +40,20 @@ Store the determined status for use in step 2.
 
 ### 2. Create the Story Issue
 
-Write the draft body (without YAML frontmatter) to a temp file and create the issue with the full set of labels:
+Write the draft body (without YAML frontmatter) to a temp file and create the issue with the full set of labels.
+
+Slugify the story name for the temp file path — lowercase, replace non-alphanumeric characters with hyphens, collapse consecutive hyphens, strip leading/trailing hyphens.
 
 ```bash
-cat <<'BODY' > /tmp/sdlc-story-body.md
+# SLUG = slugified <name> (e.g., "Fix temp file collision" -> "fix-temp-file-collision")
+
+cat <<'BODY' > /tmp/sdlc-story-<SLUG>-body.md
 <draft body content without frontmatter>
 BODY
 
 STORY_URL=$(gh issue create \
   --title "<name>" \
-  --body-file /tmp/sdlc-story-body.md \
+  --body-file /tmp/sdlc-story-<SLUG>-body.md \
   --label "type:story" \
   --label "priority:<priority>" \
   --label "area:<area1>" \
@@ -106,7 +110,7 @@ echo "$UPDATED_BLOCKER_BODY" | gh issue edit <N> --body-file -
 ### 5. Clean Up Temp Files
 
 ```bash
-rm -f /tmp/sdlc-story-body.md
+rm -f /tmp/sdlc-story-<SLUG>-body.md
 ```
 
 **Note:** Stories never get branches at creation time. Use `/sdlc:setup-dev` to create a story branch when development begins.

--- a/.claude/plugins/sdlc/agents/update-agent/reference/epic-update.md
+++ b/.claude/plugins/sdlc/agents/update-agent/reference/epic-update.md
@@ -31,8 +31,10 @@ This is idempotent — if a branch is already linked, this step is a no-op.
 
 ### Step 1: Read current body
 
+Slugify the current issue title for the temp file path — lowercase, replace non-alphanumeric characters with hyphens, collapse consecutive hyphens, strip leading/trailing hyphens.
+
 ```bash
-gh issue view <N> --json body --jq '.body' > /tmp/sdlc-update-body.md
+gh issue view <N> --json body --jq '.body' > /tmp/sdlc-epic-<N>-<SLUG>-body.md
 ```
 
 Also read the full issue metadata for context:
@@ -43,7 +45,7 @@ gh issue view <N> --json number,title,body,labels,state
 
 ### Step 2: Modify the specific section
 
-Read `/tmp/sdlc-update-body.md`, identify the section to change, and modify ONLY that section.
+Read `/tmp/sdlc-epic-<N>-<SLUG>-body.md`, identify the section to change, and modify ONLY that section.
 
 Common sections in an epic body:
 - `## Overview` — description
@@ -55,7 +57,7 @@ Common sections in an epic body:
 ### Step 3: Write back the full updated body
 
 ```bash
-gh issue edit <N> --body-file /tmp/sdlc-update-body.md
+gh issue edit <N> --body-file /tmp/sdlc-epic-<N>-<SLUG>-body.md
 ```
 
 ### Label Changes
@@ -80,7 +82,7 @@ gh issue edit <N> --title "New Epic Title"
 ### Clean Up
 
 ```bash
-rm -f /tmp/sdlc-update-body.md
+rm -f /tmp/sdlc-epic-<N>-<SLUG>-body.md
 ```
 
 ## Dependency Maintenance
@@ -94,10 +96,10 @@ When changing `Blocked by` or `Blocks` in the Dependencies section:
 
 ```bash
 # Read the blocker's body
-gh issue view <X> --json body --jq '.body' > /tmp/sdlc-blocker-body.md
+gh issue view <X> --json body --jq '.body' > /tmp/sdlc-epic-<N>-<SLUG>-blocker-body.md
 ```
 
-Modify `/tmp/sdlc-blocker-body.md`:
+Modify `/tmp/sdlc-epic-<N>-<SLUG>-blocker-body.md`:
 - If `Blocks: none` -> replace with `Blocks: #<N>`
 - If `Blocks: #A` -> change to `Blocks: #A, #<N>`
 - If `Blocks: #A, #B` -> change to `Blocks: #A, #B, #<N>`
@@ -109,14 +111,21 @@ Modify `/tmp/sdlc-blocker-body.md`:
   ```
 
 ```bash
-gh issue edit <X> --body-file /tmp/sdlc-blocker-body.md
-rm -f /tmp/sdlc-blocker-body.md
+gh issue edit <X> --body-file /tmp/sdlc-epic-<N>-<SLUG>-blocker-body.md
+rm -f /tmp/sdlc-epic-<N>-<SLUG>-blocker-body.md
 ```
 
 ### Removing a blocker (`Blocked by: #X`)
 
 1. Update this epic's body: remove `#X` from the `Blocked by:` line (if it was the only one, set to `none`).
 2. Update issue #X's body: remove `#<N>` from its `Blocks:` line (if it was the only one, set to `none`).
+
+```bash
+gh issue view <X> --json body --jq '.body' > /tmp/sdlc-epic-<N>-<SLUG>-blocker-body.md
+# Remove #<N> from the "Blocks:" line
+gh issue edit <X> --body-file /tmp/sdlc-epic-<N>-<SLUG>-blocker-body.md
+rm -f /tmp/sdlc-epic-<N>-<SLUG>-blocker-body.md
+```
 
 ### Circular Dependency Check
 

--- a/.claude/plugins/sdlc/agents/update-agent/reference/feature-update.md
+++ b/.claude/plugins/sdlc/agents/update-agent/reference/feature-update.md
@@ -30,8 +30,10 @@ This is idempotent — if a branch is already linked, this step is a no-op.
 
 ### Step 1: Read current body
 
+Slugify the current issue title for the temp file path — lowercase, replace non-alphanumeric characters with hyphens, collapse consecutive hyphens, strip leading/trailing hyphens.
+
 ```bash
-gh issue view <N> --json body --jq '.body' > /tmp/sdlc-update-body.md
+gh issue view <N> --json body --jq '.body' > /tmp/sdlc-feature-<N>-<SLUG>-body.md
 ```
 
 Also read the full issue metadata for context:
@@ -42,7 +44,7 @@ gh issue view <N> --json number,title,body,labels,state
 
 ### Step 2: Modify the specific section
 
-Read `/tmp/sdlc-update-body.md`, identify the section to change, and modify ONLY that section.
+Read `/tmp/sdlc-feature-<N>-<SLUG>-body.md`, identify the section to change, and modify ONLY that section.
 
 Common sections in a feature body:
 - `## Description` — feature description
@@ -56,7 +58,7 @@ Common sections in a feature body:
 ### Step 3: Write back the full updated body
 
 ```bash
-gh issue edit <N> --body-file /tmp/sdlc-update-body.md
+gh issue edit <N> --body-file /tmp/sdlc-feature-<N>-<SLUG>-body.md
 ```
 
 ### Label Changes
@@ -88,7 +90,7 @@ gh issue edit <N> --title "New Feature Title"
 ### Clean Up
 
 ```bash
-rm -f /tmp/sdlc-update-body.md
+rm -f /tmp/sdlc-feature-<N>-<SLUG>-body.md
 ```
 
 ## Dependency Maintenance
@@ -102,10 +104,10 @@ When changing `Blocked by` or `Blocks` in the Dependencies section:
 
 ```bash
 # Read the blocker's body
-gh issue view <X> --json body --jq '.body' > /tmp/sdlc-blocker-body.md
+gh issue view <X> --json body --jq '.body' > /tmp/sdlc-feature-<N>-<SLUG>-blocker-body.md
 ```
 
-Modify `/tmp/sdlc-blocker-body.md`:
+Modify `/tmp/sdlc-feature-<N>-<SLUG>-blocker-body.md`:
 - If `Blocks: none` -> replace with `Blocks: #<N>`
 - If `Blocks: #A` -> change to `Blocks: #A, #<N>`
 - If `Blocks: #A, #B` -> change to `Blocks: #A, #B, #<N>`
@@ -117,14 +119,21 @@ Modify `/tmp/sdlc-blocker-body.md`:
   ```
 
 ```bash
-gh issue edit <X> --body-file /tmp/sdlc-blocker-body.md
-rm -f /tmp/sdlc-blocker-body.md
+gh issue edit <X> --body-file /tmp/sdlc-feature-<N>-<SLUG>-blocker-body.md
+rm -f /tmp/sdlc-feature-<N>-<SLUG>-blocker-body.md
 ```
 
 ### Removing a blocker (`Blocked by: #X`)
 
 1. Update this feature's body: remove `#X` from the `Blocked by:` line (if it was the only one, set to `none`).
 2. Update issue #X's body: remove `#<N>` from its `Blocks:` line (if it was the only one, set to `none`).
+
+```bash
+gh issue view <X> --json body --jq '.body' > /tmp/sdlc-feature-<N>-<SLUG>-blocker-body.md
+# Remove #<N> from the "Blocks:" line
+gh issue edit <X> --body-file /tmp/sdlc-feature-<N>-<SLUG>-blocker-body.md
+rm -f /tmp/sdlc-feature-<N>-<SLUG>-blocker-body.md
+```
 
 ### Circular Dependency Check
 
@@ -149,14 +158,14 @@ After updating a feature:
 
 ```bash
 # Read parent epic body
-gh issue view <parent-epic> --json body --jq '.body' > /tmp/sdlc-parent-body.md
+gh issue view <parent-epic> --json body --jq '.body' > /tmp/sdlc-feature-<N>-<SLUG>-parent-body.md
 ```
 
 Find the line referencing this feature's old title and replace it with the new title. Keep the issue number reference intact.
 
 ```bash
-gh issue edit <parent-epic> --body-file /tmp/sdlc-parent-body.md
-rm -f /tmp/sdlc-parent-body.md
+gh issue edit <parent-epic> --body-file /tmp/sdlc-feature-<N>-<SLUG>-parent-body.md
+rm -f /tmp/sdlc-feature-<N>-<SLUG>-parent-body.md
 ```
 
 Also check the active PI issue for references to the old title:

--- a/.claude/plugins/sdlc/agents/update-agent/reference/pi-update.md
+++ b/.claude/plugins/sdlc/agents/update-agent/reference/pi-update.md
@@ -15,7 +15,9 @@
 - 3+ fields changing
 - Goal rewrite
 
-## Edit Pattern
+## Read-Modify-Write Pattern
+
+**The `gh issue edit --body` flag replaces the ENTIRE body.** There is no partial edit. Always use the read-modify-write pattern.
 
 ### Step 0: Ensure Branch Exists
 
@@ -27,59 +29,52 @@ Follow [`branch-creation.md`](../create-agent/reference/branch-creation.md) with
 
 This is idempotent — if a branch is already linked, this step is a no-op.
 
-### Read current PI
+### Step 1: Read current body
+
+Slugify the current issue title for the temp file path — lowercase, replace non-alphanumeric characters with hyphens, collapse consecutive hyphens, strip leading/trailing hyphens.
 
 ```bash
-gh issue view <N> --json body,title,labels
+gh issue view <N> --json body --jq '.body' > /tmp/sdlc-pi-<N>-<SLUG>-body.md
 ```
 
-### Make targeted edits
-
-Extract the `body` field, apply string manipulation to modify only the targeted content, then write it back. Do NOT rewrite the entire body — change only the targeted section.
-
-### Common direct updates
-
-**Date change:**
-Update the `started` or `target` field in the metadata section of the body, then:
+Also read the full issue metadata for context:
 
 ```bash
-gh issue edit <N> --body "$UPDATED_BODY"
+gh issue view <N> --json number,title,body,labels,state
 ```
 
-**Theme tweak:**
-Update the `theme` field in the metadata section of the body, then:
+### Step 2: Modify the specific section
+
+Read `/tmp/sdlc-pi-<N>-<SLUG>-body.md`, identify the section to change, and modify ONLY that section.
+
+Common sections in a PI body:
+- `## Goals` — objectives for the increment
+- `## Timeline` — start/target dates
+- `## Epics` — child epic subsections with status annotations
+
+### Step 3: Write back the full updated body
 
 ```bash
-gh issue edit <N> --body "$UPDATED_BODY"
+gh issue edit <N> --body-file /tmp/sdlc-pi-<N>-<SLUG>-body.md
 ```
 
-**Status update for an epic entry:**
-Find the epic line in the `## Epics` section of the body, update its status annotation, then:
-
-```bash
-gh issue edit <N> --body "$UPDATED_BODY"
-```
-
-**Single epic/feature rename:**
-Find the line referencing the old name, replace it with the new name (keeping the issue number reference intact), then:
-
-```bash
-gh issue edit <N> --body "$UPDATED_BODY"
-```
-
-**Title change:**
+### Title Changes
 
 ```bash
 gh issue edit <N> --title "<new title>"
 ```
 
-**Label change:**
+### Label Changes
 
 ```bash
 gh issue edit <N> --add-label "<label>" --remove-label "<label>"
 ```
 
-Use a descriptive description of what changed: `gh issue edit <N> --body "$UPDATED_BODY"` extending the target date, or renaming an epic entry.
+### Clean Up
+
+```bash
+rm -f /tmp/sdlc-pi-<N>-<SLUG>-body.md
+```
 
 ## Cascade Rules
 

--- a/.claude/plugins/sdlc/agents/update-agent/reference/story-update.md
+++ b/.claude/plugins/sdlc/agents/update-agent/reference/story-update.md
@@ -23,8 +23,10 @@ Stories do not have branches created by the update agent. Use `/sdlc:setup-dev` 
 
 ### Step 1: Read current body
 
+Slugify the current issue title for the temp file path — lowercase, replace non-alphanumeric characters with hyphens, collapse consecutive hyphens, strip leading/trailing hyphens.
+
 ```bash
-gh issue view <N> --json body --jq '.body' > /tmp/sdlc-update-body.md
+gh issue view <N> --json body --jq '.body' > /tmp/sdlc-story-<N>-<SLUG>-body.md
 ```
 
 Also read the full issue metadata for context:
@@ -35,7 +37,7 @@ gh issue view <N> --json number,title,body,labels,state
 
 ### Step 2: Modify the specific section
 
-Read `/tmp/sdlc-update-body.md`, identify the section to change, and modify ONLY that section.
+Read `/tmp/sdlc-story-<N>-<SLUG>-body.md`, identify the section to change, and modify ONLY that section.
 
 Common sections in a story body:
 - `## Description` — story description
@@ -48,7 +50,7 @@ Common sections in a story body:
 ### Step 3: Write back the full updated body
 
 ```bash
-gh issue edit <N> --body-file /tmp/sdlc-update-body.md
+gh issue edit <N> --body-file /tmp/sdlc-story-<N>-<SLUG>-body.md
 ```
 
 ### Label Changes
@@ -74,7 +76,7 @@ gh issue edit <N> --title "feat(auth): new story title"
 ### Clean Up
 
 ```bash
-rm -f /tmp/sdlc-update-body.md
+rm -f /tmp/sdlc-story-<N>-<SLUG>-body.md
 ```
 
 ## Dependency Maintenance
@@ -88,10 +90,10 @@ When changing `Blocked by` or `Blocks` in the Dependencies section:
 
 ```bash
 # Read the blocker's body
-gh issue view <X> --json body --jq '.body' > /tmp/sdlc-blocker-body.md
+gh issue view <X> --json body --jq '.body' > /tmp/sdlc-story-<N>-<SLUG>-blocker-body.md
 ```
 
-Modify `/tmp/sdlc-blocker-body.md`:
+Modify `/tmp/sdlc-story-<N>-<SLUG>-blocker-body.md`:
 - If `Blocks: none` -> replace with `Blocks: #<N>`
 - If `Blocks: #A` -> change to `Blocks: #A, #<N>`
 - If `Blocks: #A, #B` -> change to `Blocks: #A, #B, #<N>`
@@ -103,14 +105,21 @@ Modify `/tmp/sdlc-blocker-body.md`:
   ```
 
 ```bash
-gh issue edit <X> --body-file /tmp/sdlc-blocker-body.md
-rm -f /tmp/sdlc-blocker-body.md
+gh issue edit <X> --body-file /tmp/sdlc-story-<N>-<SLUG>-blocker-body.md
+rm -f /tmp/sdlc-story-<N>-<SLUG>-blocker-body.md
 ```
 
 ### Removing a blocker (`Blocked by: #X`)
 
 1. Update this story's body: remove `#X` from the `Blocked by:` line (if it was the only one, set to `none`).
 2. Update issue #X's body: remove `#<N>` from its `Blocks:` line (if it was the only one, set to `none`).
+
+```bash
+gh issue view <X> --json body --jq '.body' > /tmp/sdlc-story-<N>-<SLUG>-blocker-body.md
+# Remove #<N> from the "Blocks:" line
+gh issue edit <X> --body-file /tmp/sdlc-story-<N>-<SLUG>-blocker-body.md
+rm -f /tmp/sdlc-story-<N>-<SLUG>-blocker-body.md
+```
 
 ### Circular Dependency Check
 
@@ -167,14 +176,14 @@ After updating a story:
 
 ```bash
 # Read parent feature body
-gh issue view <parent-feature> --json body --jq '.body' > /tmp/sdlc-parent-body.md
+gh issue view <parent-feature> --json body --jq '.body' > /tmp/sdlc-story-<N>-<SLUG>-parent-body.md
 ```
 
 Find the line referencing this story's old title and replace it with the new title. Keep the issue number reference intact.
 
 ```bash
-gh issue edit <parent-feature> --body-file /tmp/sdlc-parent-body.md
-rm -f /tmp/sdlc-parent-body.md
+gh issue edit <parent-feature> --body-file /tmp/sdlc-story-<N>-<SLUG>-parent-body.md
+rm -f /tmp/sdlc-story-<N>-<SLUG>-parent-body.md
 ```
 
 - **If deps changed**: bidirectional updates and status recalculation handled in Dependency Maintenance above.


### PR DESCRIPTION
## Summary

Replace all hardcoded temp file paths across execution and update agent references with unique slugified paths, preventing race conditions when parallel agents of the same type write simultaneously. Also refactors `pi-update.md` from inline `$UPDATED_BODY` shell variable to the temp file read-modify-write pattern used by all other update references.

## Test Plan

- [ ] **Creation reference paths**: Verify each creation reference (`pi-execution.md`, `epic-execution.md`, `feature-execution.md`, `story-execution.md`) uses `/tmp/sdlc-<level>-<SLUG>-body.md` with matching `rm -f` cleanup
- [ ] **Update reference paths**: Verify each update reference (`pi-update.md`, `epic-update.md`, `feature-update.md`, `story-update.md`) uses `/tmp/sdlc-<level>-<N>-<SLUG>-body.md` with matching cleanup
- [ ] **Blocker temp files**: Confirm `epic-update.md`, `feature-update.md`, `story-update.md` use `/tmp/sdlc-<level>-<N>-<SLUG>-blocker-body.md` for both adding and removing blockers
- [ ] **Parent temp files**: Confirm `feature-update.md` and `story-update.md` use `/tmp/sdlc-<level>-<N>-<SLUG>-parent-body.md` for cascade title updates
- [ ] **pi-update.md refactor**: Verify the old `$UPDATED_BODY` / `--body` pattern is fully replaced with Step 1 (read to temp file) → Step 2 (modify) → Step 3 (write back via `--body-file`) → Clean Up (`rm -f`)
- [ ] **No stale paths**: `grep -r '/tmp/sdlc-(update|blocker|parent|pi|epic|feature|story)-body\.md'` returns zero matches across the agents directory
- [ ] **Slugification instruction**: Each file includes inline slugification algorithm (lowercase, non-alphanumeric to hyphen, collapse, strip) without external file references
- [ ] **Parallel safety**: Dispatch 3 story create-agents under the same feature — each should write to a distinct `/tmp/sdlc-story-<SLUG>-body.md` path based on its unique story name

---

Closes #62