### PR TITLE
fix(#58): size-labels-missing-color-hierarchy-for-visual-distinction

### DIFF
--- a/.claude/plugins/sdlc/skills/init/SKILL.md
+++ b/.claude/plugins/sdlc/skills/init/SKILL.md
@@ -92,9 +92,9 @@ gh label create "priority:high" --color "d93f0b" --force
 gh label create "priority:medium" --color "fbca04" --force
 gh label create "priority:low" --color "c5def5" --force
 
-# Size labels (yellow-green)
+# Size labels (yellow-green gradient: lighter = smaller)
 gh label create "size:small" --color "e4e669" --force
-gh label create "size:large" --color "e4e669" --force
+gh label create "size:large" --color "c9c642" --force
 
 # Triage (yellow)
 gh label create "triage" --color "fbca04" --force


### PR DESCRIPTION
## Summary

Adds a color gradient to size labels in `sdlc:init` so `size:small` and `size:large` are visually distinguishable. `size:large` darkened from `e4e669` to `c9c642`, consistent with the gradient pattern used by priority and other label groups.

## Test Plan

- [ ] Run `sdlc:init` and verify `size:small` is created with color `e4e669` and `size:large` with `c9c642`
- [ ] Confirm the two size labels are visually distinct in GitHub's label list
- [ ] Verify `size:large` color (`c9c642`) does not visually conflict with `status:done` (`0e8a16`) — should be clearly yellow-green, not green
- [ ] Confirm no other label colors were changed (type, status, priority, triage, area labels remain unchanged)

---

Closes #58