### PR TITLE
chore(#69): bug-and-chore-workflow-improvements

### DIFF
--- a/.claude/plugins/sdlc/agents/create-agent/AGENT.md
+++ b/.claude/plugins/sdlc/agents/create-agent/AGENT.md
@@ -10,7 +10,7 @@ You are the create agent for the SDLC plugin. You create artifacts from drafts b
 
 You receive:
 - **Draft file path** — the draft to create from
-- **Artifact level** — prd, pi, epic, feature, or story
+- **Artifact level** — prd, pi, epic, feature, story, bug, or chore
 
 ## Behavior
 

--- a/.claude/plugins/sdlc/agents/create-agent/reference/bug-execution.md
+++ b/.claude/plugins/sdlc/agents/create-agent/reference/bug-execution.md
@@ -1,0 +1,93 @@
+# Bug Execution Reference
+
+## Required Fields
+
+### Frontmatter
+- `name` — bug name
+- `severity` — one of: `critical`, `high`, `medium`, `low`
+- `priority` — one of: `critical`, `high`, `medium`, `low`
+- `areas` — array of area labels
+
+### Optional Frontmatter
+- `parent-pi` — issue number of the parent PI
+- `parent-epic` — issue number of the parent epic
+- `parent-feature` — issue number of the parent feature
+
+### Body Sections
+- `## Description` — non-empty
+- `## Reproduction Steps` — non-empty (or "Not yet reproduced" with context)
+
+Additional sections (Expected vs Actual Behavior, Affected Areas, File Scope, Technical Notes, Dependencies, Parent) are expected but not blocking.
+
+## Execution Steps
+
+### 1. Create the Bug Issue
+
+Write the draft body (without YAML frontmatter) to a temp file and create the issue with the full set of labels.
+
+Slugify the bug name for the temp file path — lowercase, replace non-alphanumeric characters with hyphens, collapse consecutive hyphens, strip leading/trailing hyphens.
+
+```bash
+# SLUG = slugified <name> (e.g., "Draft reviewer rejects valid bugs" -> "draft-reviewer-rejects-valid-bugs")
+
+cat <<'BODY' > /tmp/sdlc-bug-<SLUG>-body.md
+<draft body content without frontmatter>
+BODY
+
+BUG_URL=$(gh issue create \
+  --title "<name>" \
+  --body-file /tmp/sdlc-bug-<SLUG>-body.md \
+  --label "type:bug" \
+  --label "severity:<severity>" \
+  --label "priority:<priority>" \
+  --label "area:<area1>" \
+  --label "area:<area2>")
+BUG_NUM=$(echo "$BUG_URL" | grep -o '[0-9]*$')
+```
+
+**Label rules:**
+- `type:bug` — always
+- `severity:<severity>` — from frontmatter
+- `priority:<priority>` — from frontmatter
+- `area:<area>` — one `--label` per area from frontmatter
+- Do NOT add `status:` labels — bugs do not carry status labels
+
+### 2. Bidirectional Dependency Linking
+
+If the bug draft has `Blocked by: #N, #M` in its Dependencies section:
+
+For each referenced blocker issue number:
+
+```bash
+# Read the blocker's body
+BLOCKER_BODY=$(gh issue view <N> --json body --jq '.body')
+
+# Update the "Blocks:" line in the blocker's Dependencies section:
+# - If "Blocks: none" -> replace with "Blocks: #<BUG_NUM>"
+# - If "Blocks: #X" -> change to "Blocks: #X, #<BUG_NUM>"
+# - If "Blocks: #X, #Y" -> change to "Blocks: #X, #Y, #<BUG_NUM>"
+# - If no Dependencies section exists -> append:
+#     ## Dependencies
+#     - Blocked by: (unchanged)
+#     - Blocks: #<BUG_NUM>
+
+# Write back
+echo "$UPDATED_BLOCKER_BODY" | gh issue edit <N> --body-file -
+```
+
+### 3. Clean Up Temp Files
+
+```bash
+rm -f /tmp/sdlc-bug-<SLUG>-body.md
+```
+
+**Note:** Bugs never get branches at creation time. Use `/sdlc:setup-dev` to create a bug branch when development begins. Bugs are NOT tracked in parent checklists — they relate to parents via the `## Parent` section only.
+
+## Report Format
+
+> **Created:**
+> - Bug: #`<BUG_NUM>` — "`<name>`"
+>   - Labels: `type:bug`, `severity:<severity>`, `priority:<priority>`, `area:<areas>`
+>
+> **Updated:**
+> - Blocker #`<N>` body: added `Blocks: #<BUG_NUM>` to Dependencies

--- a/.claude/plugins/sdlc/agents/create-agent/reference/chore-execution.md
+++ b/.claude/plugins/sdlc/agents/create-agent/reference/chore-execution.md
@@ -1,0 +1,91 @@
+# Chore Execution Reference
+
+## Required Fields
+
+### Frontmatter
+- `name` — chore name
+- `priority` — one of: `critical`, `high`, `medium`, `low`
+- `areas` — array of area labels
+
+### Optional Frontmatter
+- `parent-pi` — issue number of the parent PI
+- `parent-epic` — issue number of the parent epic
+- `parent-feature` — issue number of the parent feature
+
+### Body Sections
+- `## Description` — non-empty
+- `## Task` — non-empty
+- `## Acceptance Criteria` — at least one checkbox item
+
+Additional sections (File Scope, Technical Notes, Dependencies, Parent) are expected but not blocking.
+
+## Execution Steps
+
+### 1. Create the Chore Issue
+
+Write the draft body (without YAML frontmatter) to a temp file and create the issue with the full set of labels.
+
+Slugify the chore name for the temp file path — lowercase, replace non-alphanumeric characters with hyphens, collapse consecutive hyphens, strip leading/trailing hyphens.
+
+```bash
+# SLUG = slugified <name> (e.g., "Migrate config to YAML" -> "migrate-config-to-yaml")
+
+cat <<'BODY' > /tmp/sdlc-chore-<SLUG>-body.md
+<draft body content without frontmatter>
+BODY
+
+CHORE_URL=$(gh issue create \
+  --title "<name>" \
+  --body-file /tmp/sdlc-chore-<SLUG>-body.md \
+  --label "type:chore" \
+  --label "priority:<priority>" \
+  --label "area:<area1>" \
+  --label "area:<area2>")
+CHORE_NUM=$(echo "$CHORE_URL" | grep -o '[0-9]*$')
+```
+
+**Label rules:**
+- `type:chore` — always
+- `priority:<priority>` — from frontmatter
+- `area:<area>` — one `--label` per area from frontmatter
+- Do NOT add `status:` labels — chores do not carry status labels
+
+### 2. Bidirectional Dependency Linking
+
+If the chore draft has `Blocked by: #N, #M` in its Dependencies section:
+
+For each referenced blocker issue number:
+
+```bash
+# Read the blocker's body
+BLOCKER_BODY=$(gh issue view <N> --json body --jq '.body')
+
+# Update the "Blocks:" line in the blocker's Dependencies section:
+# - If "Blocks: none" -> replace with "Blocks: #<CHORE_NUM>"
+# - If "Blocks: #X" -> change to "Blocks: #X, #<CHORE_NUM>"
+# - If "Blocks: #X, #Y" -> change to "Blocks: #X, #Y, #<CHORE_NUM>"
+# - If no Dependencies section exists -> append:
+#     ## Dependencies
+#     - Blocked by: (unchanged)
+#     - Blocks: #<CHORE_NUM>
+
+# Write back
+echo "$UPDATED_BLOCKER_BODY" | gh issue edit <N> --body-file -
+```
+
+### 3. Clean Up Temp Files
+
+```bash
+rm -f /tmp/sdlc-chore-<SLUG>-body.md
+```
+
+**Note:** Chores never get branches at creation time. Use `/sdlc:setup-dev` to create a chore branch when development begins. Chores are NOT tracked in parent checklists — they relate to parents via the `## Parent` section only.
+
+## Report Format
+
+> **Created:**
+> - Chore: #`<CHORE_NUM>` — "`<name>`"
+>   - Labels: `type:chore`, `priority:<priority>`, `area:<areas>`
+>
+> **Updated:**
+> - Blocker #`<N>` body: added `Blocks: #<CHORE_NUM>` to Dependencies

--- a/.claude/plugins/sdlc/agents/draft-reviewer/AGENT.md
+++ b/.claude/plugins/sdlc/agents/draft-reviewer/AGENT.md
@@ -10,7 +10,7 @@ You are a draft reviewer for the SDLC plugin. You review draft artifacts before 
 
 You receive:
 - **Draft file path** — the draft to review
-- **Level** — prd, pi, epic, feature, or story
+- **Level** — prd, pi, epic, feature, story, bug, or chore
 - **Upstream artifact paths** — files and GitHub issue numbers to validate against
 
 ## What to Check

--- a/.claude/plugins/sdlc/agents/impact-analysis-agent/AGENT.md
+++ b/.claude/plugins/sdlc/agents/impact-analysis-agent/AGENT.md
@@ -128,6 +128,7 @@ The two-pass scan gives you more data than the old targeted approach. This makes
 - Issues that share area labels but have no actual content overlap
 - Keyword matches that are coincidental (e.g., both mention "authentication" but in unrelated contexts)
 - Transitive dependency chains deeper than 2 levels (mention as "potential impact for user to investigate" only)
+- Parent checklist updates for bugs or chores — bugs and chores are NOT tracked in parent checklists (epic Features lists, feature Stories lists, PI Epics lists). They relate to parents via their own `## Parent` section only. Do not suggest adding a bug or chore to any parent's child checklist.
 
 ## Output Format
 

--- a/.claude/plugins/sdlc/agents/update-agent/AGENT.md
+++ b/.claude/plugins/sdlc/agents/update-agent/AGENT.md
@@ -10,7 +10,7 @@ You are the update agent for the SDLC plugin. You make surgical edits to existin
 
 You receive:
 - **Target** — issue number or file path of the artifact to update
-- **Level** — prd, pi, epic, feature, or story
+- **Level** — prd, pi, epic, feature, story, bug, or chore
 - **Change** — structured description: which section, what to change, old value, new value
 
 ## Behavior

--- a/.claude/plugins/sdlc/agents/update-agent/reference/bug-update.md
+++ b/.claude/plugins/sdlc/agents/update-agent/reference/bug-update.md
@@ -1,0 +1,148 @@
+# Bug Update Reference
+
+## Direct Update Criteria
+
+**DIRECT** if all true:
+- 1-2 fields changing (description edit, severity change, priority change, title edit, reproduction steps update, technical notes update, file scope change within same area)
+- No fundamental rework of the bug's scope or root cause
+- No scope expansion (bug doesn't grow to cover entirely new areas or root causes)
+
+**ESCALATE** if any true:
+- Root cause analysis reveals fundamentally different problem than originally described
+- Scope expansion (bug affects entirely new areas not originally identified)
+- 3+ fields changing
+- Bug needs to be split into multiple bugs
+
+Bugs do not have branches created by the update agent. Use `/sdlc:setup-dev` to create a bug branch.
+
+## Read-Modify-Write Pattern
+
+**The `gh issue edit --body` flag replaces the ENTIRE body.** There is no partial edit. Always use the read-modify-write pattern.
+
+### Step 1: Read current body
+
+Slugify the current issue title for the temp file path — lowercase, replace non-alphanumeric characters with hyphens, collapse consecutive hyphens, strip leading/trailing hyphens.
+
+```bash
+gh issue view <N> --json body --jq '.body' > /tmp/sdlc-bug-<N>-<SLUG>-body.md
+```
+
+Also read the full issue metadata for context:
+
+```bash
+gh issue view <N> --json number,title,body,labels,state
+```
+
+### Step 2: Modify the specific section
+
+Read `/tmp/sdlc-bug-<N>-<SLUG>-body.md`, identify the section to change, and modify ONLY that section.
+
+Common sections in a bug body:
+- `## Description` — what's broken
+- `## Reproduction Steps` — steps to reproduce
+- `## Expected vs Actual Behavior` — what should vs does happen
+- `## Affected Areas` — impacted parts of the system
+- `## File Scope` — known files involved
+- `## Technical Notes` — implementation considerations, root cause analysis
+- `## Dependencies` — `Blocked by:` and `Blocks:` lines
+- `## Parent` — PI, epic, and/or feature references (if parented)
+
+### Step 3: Write back the full updated body
+
+```bash
+gh issue edit <N> --body-file /tmp/sdlc-bug-<N>-<SLUG>-body.md
+```
+
+### Label Changes
+
+```bash
+# Change severity
+gh issue edit <N> --add-label "severity:high" --remove-label "severity:medium"
+
+# Change priority
+gh issue edit <N> --add-label "priority:high" --remove-label "priority:medium"
+
+# Add/remove area
+gh issue edit <N> --add-label "area:api"
+gh issue edit <N> --remove-label "area:api"
+```
+
+### Title Changes
+
+```bash
+gh issue edit <N> --title "bug: new bug title"
+```
+
+### Clean Up
+
+```bash
+rm -f /tmp/sdlc-bug-<N>-<SLUG>-body.md
+```
+
+## Dependency Maintenance
+
+When changing `Blocked by` or `Blocks` in the Dependencies section:
+
+### Adding a new blocker (`Blocked by: #X`)
+
+1. Update this bug's body: add `#X` to the `Blocked by:` line.
+2. Update issue #X's body: add `#<N>` to its `Blocks:` line.
+
+```bash
+# Read the blocker's body
+gh issue view <X> --json body --jq '.body' > /tmp/sdlc-bug-<N>-<SLUG>-blocker-body.md
+```
+
+Modify `/tmp/sdlc-bug-<N>-<SLUG>-blocker-body.md`:
+- If `Blocks: none` -> replace with `Blocks: #<N>`
+- If `Blocks: #A` -> change to `Blocks: #A, #<N>`
+- If `Blocks: #A, #B` -> change to `Blocks: #A, #B, #<N>`
+- If no Dependencies section exists -> append:
+  ```
+  ## Dependencies
+  - Blocked by: none
+  - Blocks: #<N>
+  ```
+
+```bash
+gh issue edit <X> --body-file /tmp/sdlc-bug-<N>-<SLUG>-blocker-body.md
+rm -f /tmp/sdlc-bug-<N>-<SLUG>-blocker-body.md
+```
+
+### Removing a blocker (`Blocked by: #X`)
+
+1. Update this bug's body: remove `#X` from the `Blocked by:` line (if it was the only one, set to `none`).
+2. Update issue #X's body: remove `#<N>` from its `Blocks:` line (if it was the only one, set to `none`).
+
+```bash
+gh issue view <X> --json body --jq '.body' > /tmp/sdlc-bug-<N>-<SLUG>-blocker-body.md
+# Remove #<N> from the "Blocks:" line
+gh issue edit <X> --body-file /tmp/sdlc-bug-<N>-<SLUG>-blocker-body.md
+rm -f /tmp/sdlc-bug-<N>-<SLUG>-blocker-body.md
+```
+
+### Circular Dependency Check
+
+After any dependency change, verify no circular dependency exists. Walk the blocker chain using DFS:
+
+```bash
+# Start from this bug's blockers
+# For each blocker, read its body and parse "Blocked by:" line
+# For each of those, do the same
+# If we encounter the original bug number, there's a cycle
+
+gh issue view <blocker> --json body --jq '.body'
+# Parse "Blocked by:" line, recurse
+```
+
+If a circular dependency is detected: STOP, report the cycle to the user, and revert the dependency change.
+
+> "Circular dependency detected: #<N> -> #<X> -> #<Y> -> #<N>. Reverting the dependency change."
+
+## Cascade Rules
+
+Bugs are NOT tracked in parent checklists. After updating a bug:
+
+- **If title changed**: no parent cascade needed — bugs are not listed in parent issue checklists.
+- **If deps changed**: bidirectional updates handled in Dependency Maintenance above.
+- **If scope changed** (via escalation + reshape draft): no automatic cascade.

--- a/.claude/plugins/sdlc/agents/update-agent/reference/chore-update.md
+++ b/.claude/plugins/sdlc/agents/update-agent/reference/chore-update.md
@@ -1,0 +1,146 @@
+# Chore Update Reference
+
+## Direct Update Criteria
+
+**DIRECT** if all true:
+- 1-2 fields changing (description edit, priority change, title edit, task update, technical notes update, file scope change within same area)
+- No scope expansion (chore doesn't grow to cover new files/areas beyond its current scope)
+- No fundamental rework of the chore's purpose
+- Acceptance criteria changes limited to 1-2 items (add, remove, or reword)
+
+**ESCALATE** if any true:
+- Scope expansion (new files or areas not originally in scope)
+- Fundamental rework (chore purpose or approach changes)
+- AC overhaul (3+ acceptance criteria changing)
+- 3+ fields changing
+- Chore needs to be split
+
+Chores do not have branches created by the update agent. Use `/sdlc:setup-dev` to create a chore branch.
+
+## Read-Modify-Write Pattern
+
+**The `gh issue edit --body` flag replaces the ENTIRE body.** There is no partial edit. Always use the read-modify-write pattern.
+
+### Step 1: Read current body
+
+Slugify the current issue title for the temp file path — lowercase, replace non-alphanumeric characters with hyphens, collapse consecutive hyphens, strip leading/trailing hyphens.
+
+```bash
+gh issue view <N> --json body --jq '.body' > /tmp/sdlc-chore-<N>-<SLUG>-body.md
+```
+
+Also read the full issue metadata for context:
+
+```bash
+gh issue view <N> --json number,title,body,labels,state
+```
+
+### Step 2: Modify the specific section
+
+Read `/tmp/sdlc-chore-<N>-<SLUG>-body.md`, identify the section to change, and modify ONLY that section.
+
+Common sections in a chore body:
+- `## Description` — what needs doing and why
+- `## Task` — the specific work
+- `## Acceptance Criteria` — checkbox list
+- `## File Scope` — files/directories involved
+- `## Technical Notes` — implementation guidance
+- `## Dependencies` — `Blocked by:` and `Blocks:` lines
+- `## Parent` — PI, epic, and/or feature references (if parented)
+
+### Step 3: Write back the full updated body
+
+```bash
+gh issue edit <N> --body-file /tmp/sdlc-chore-<N>-<SLUG>-body.md
+```
+
+### Label Changes
+
+```bash
+# Change priority
+gh issue edit <N> --add-label "priority:high" --remove-label "priority:medium"
+
+# Add/remove area
+gh issue edit <N> --add-label "area:api"
+gh issue edit <N> --remove-label "area:api"
+```
+
+### Title Changes
+
+```bash
+gh issue edit <N> --title "chore: new chore title"
+```
+
+### Clean Up
+
+```bash
+rm -f /tmp/sdlc-chore-<N>-<SLUG>-body.md
+```
+
+## Dependency Maintenance
+
+When changing `Blocked by` or `Blocks` in the Dependencies section:
+
+### Adding a new blocker (`Blocked by: #X`)
+
+1. Update this chore's body: add `#X` to the `Blocked by:` line.
+2. Update issue #X's body: add `#<N>` to its `Blocks:` line.
+
+```bash
+# Read the blocker's body
+gh issue view <X> --json body --jq '.body' > /tmp/sdlc-chore-<N>-<SLUG>-blocker-body.md
+```
+
+Modify `/tmp/sdlc-chore-<N>-<SLUG>-blocker-body.md`:
+- If `Blocks: none` -> replace with `Blocks: #<N>`
+- If `Blocks: #A` -> change to `Blocks: #A, #<N>`
+- If `Blocks: #A, #B` -> change to `Blocks: #A, #B, #<N>`
+- If no Dependencies section exists -> append:
+  ```
+  ## Dependencies
+  - Blocked by: none
+  - Blocks: #<N>
+  ```
+
+```bash
+gh issue edit <X> --body-file /tmp/sdlc-chore-<N>-<SLUG>-blocker-body.md
+rm -f /tmp/sdlc-chore-<N>-<SLUG>-blocker-body.md
+```
+
+### Removing a blocker (`Blocked by: #X`)
+
+1. Update this chore's body: remove `#X` from the `Blocked by:` line (if it was the only one, set to `none`).
+2. Update issue #X's body: remove `#<N>` from its `Blocks:` line (if it was the only one, set to `none`).
+
+```bash
+gh issue view <X> --json body --jq '.body' > /tmp/sdlc-chore-<N>-<SLUG>-blocker-body.md
+# Remove #<N> from the "Blocks:" line
+gh issue edit <X> --body-file /tmp/sdlc-chore-<N>-<SLUG>-blocker-body.md
+rm -f /tmp/sdlc-chore-<N>-<SLUG>-blocker-body.md
+```
+
+### Circular Dependency Check
+
+After any dependency change, verify no circular dependency exists. Walk the blocker chain using DFS:
+
+```bash
+# Start from this chore's blockers
+# For each blocker, read its body and parse "Blocked by:" line
+# For each of those, do the same
+# If we encounter the original chore number, there's a cycle
+
+gh issue view <blocker> --json body --jq '.body'
+# Parse "Blocked by:" line, recurse
+```
+
+If a circular dependency is detected: STOP, report the cycle to the user, and revert the dependency change.
+
+> "Circular dependency detected: #<N> -> #<X> -> #<Y> -> #<N>. Reverting the dependency change."
+
+## Cascade Rules
+
+Chores are NOT tracked in parent checklists. After updating a chore:
+
+- **If title changed**: no parent cascade needed — chores are not listed in parent issue checklists.
+- **If deps changed**: bidirectional updates handled in Dependency Maintenance above.
+- **If scope changed** (via escalation + reshape draft): no automatic cascade.

--- a/.claude/plugins/sdlc/skills/capture/SKILL.md
+++ b/.claude/plugins/sdlc/skills/capture/SKILL.md
@@ -79,13 +79,17 @@ Load the template for the confirmed type from `${CLAUDE_PLUGIN_ROOT}/templates/<
 - `## Expected vs Actual Behavior` — from description or `[TBD]`
 - `## Affected Areas` — if mentioned, otherwise `[TBD]`
 - `## File Scope` — if mentioned, otherwise `[TBD]`
+- `## Technical Notes` — `[TBD]` (filled by define)
 - `## Dependencies` — `none` (capture doesn't assess dependencies)
+- **Severity:** Ask the user for severity (critical/high/medium/low) if not already clear from the description. Default suggestion: `medium` unless the description indicates otherwise.
+- **Priority:** Ask the user for priority (critical/high/medium/low) alongside severity. Default suggestion: match severity unless the user indicates otherwise.
 
 **Chore — fill from description:**
 - `## Description` — what needs doing and why
 - `## Task` — the specific work
 - `## Acceptance Criteria` — if determinable, otherwise `[TBD]`
 - `## File Scope` — if mentioned, otherwise `[TBD]`
+- `## Technical Notes` — `[TBD]` (filled by define)
 - `## Dependencies` — `none`
 - No `## Parent` section at capture time (standalone by default; can be added via `/sdlc:define chore #N` later)
 
@@ -116,7 +120,7 @@ Wait for user approval. Incorporate any feedback. Do NOT create the issue until 
 
 Create the issue with the appropriate labels:
 
-- **Bug:** `--label "type:bug"` (also add `--label "severity:<level>"` if severity was determined during capture)
+- **Bug:** `--label "type:bug"`, `--label "severity:<level>"`, and `--label "priority:<level>"` (severity and priority are always captured in Step 3)
 - **Chore:** `--label "type:chore"`
 - **Triage:** `--label "triage"`
 

--- a/.claude/plugins/sdlc/skills/define/SKILL.md
+++ b/.claude/plugins/sdlc/skills/define/SKILL.md
@@ -34,7 +34,6 @@ You MUST create a task for each of these phases and complete them in order:
 Parse `$ARGUMENTS` for an optional level and optional identifier.
 
 - If level provided: load brainstorming guide from `${CLAUDE_PLUGIN_ROOT}/skills/define/reference/<level>-brainstorm.md`
-- **Exception — chore level:** load `${CLAUDE_PLUGIN_ROOT}/skills/define/reference/story-brainstorm.md` instead (no `chore-brainstorm.md` exists). Note: parent-related questions in the story guide are conditional for chores — standalone chores skip them.
 - If no level: proceed without a guide — the brainstorm will discover the level
 - Read `.claude/sdlc/prd/PRD.md` for project context
 - Check for active PI issue: `gh issue list --label "type:pi" --state open --json number,title,body --jq '.[0]'`
@@ -49,7 +48,7 @@ Parse `$ARGUMENTS` for an optional level and optional identifier.
   - **No issue number and no existing draft** = new artifact
 - If args contain an issue number (#N) with no level keyword: infer level from the fetched issue's labels (reuse the `gh issue view` result from above):
   - Has `type:bug` label → set level to `bug`, load `bug-brainstorm.md` (via the generic rule)
-  - Has `type:chore` label → set level to `chore`, load `story-brainstorm.md` (via the chore exception)
+  - Has `type:chore` label → set level to `chore`, load `chore-brainstorm.md` (via the generic rule)
   - Has `triage` label → ask the user what level this should become (may be feature, story, bug, or chore)
   - Has any other `type:*` label (e.g., `type:feature`, `type:epic`, `type:story`, `type:pi`) → infer level from the label name, load the corresponding brainstorm guide
 
@@ -149,8 +148,12 @@ Is this a reshape? (draft has ## Changes section)
 │   │   5. Dispatch update-agent to backfill feature body: replace each #TBD with real story number
 │   ├── Feature (size:small):
 │   │   1. Dispatch create-agent for feature (no children)
-│   └── Story:
-│       1. Dispatch create-agent for story (no children)
+│   ├── Story:
+│   │   1. Dispatch create-agent for story (no children)
+│   ├── Bug:
+│   │   1. Dispatch create-agent for bug (no children)
+│   └── Chore:
+│       1. Dispatch create-agent for chore (no children)
 ~~~
 
 **Draft cleanup:** After all Phase 8 agents complete successfully (primary created, all children created, backfill complete), delete the working draft:
@@ -196,6 +199,8 @@ Informational guidance — no dispatching, no "want me to create?". Content is l
 - **Feature (large)** → "Stories #A, #B created as stubs. Run `/sdlc:define story #A` to flesh one out."
 - **Feature (small)** → "Feature is directly implementable. Ready to develop."
 - **Story** → "Next unfinished story under this feature is #B, or all stories defined — ready to develop."
+- **Bug** → "Bug is ready to develop. Run `/sdlc:setup-dev #N` to start."
+- **Chore** → "Chore is ready to develop. Run `/sdlc:setup-dev #N` to start."
 - **PRD** → "Committed. Run `/sdlc:define epic` to start decomposing."
 - **PI** → "Created as GitHub Issue. Run `/sdlc:define epic` to start decomposing."
 
@@ -208,8 +213,8 @@ Informational guidance — no dispatching, no "want me to create?". Content is l
 | Epic | PRD exists. PI exists. |
 | Feature | PRD exists. PI exists. Parent epic resolvable via `gh issue view`. |
 | Story | PRD exists. Parent feature and parent epic resolvable via `gh issue view`. |
-| Bug | PRD exists. No parent requirements — bugs are peers to the hierarchy. |
-| Chore | PRD exists. If parented, parent epic/feature resolvable via `gh issue view`. |
+| Bug | PRD exists. If parented, parent PI/epic/feature resolvable via `gh issue view`. |
+| Chore | PRD exists. If parented, parent PI/epic/feature resolvable via `gh issue view`. |
 
 If prerequisites are missing, tell the user what needs to exist first and suggest the appropriate `/sdlc:define` invocation.
 

--- a/.claude/plugins/sdlc/skills/define/reference/bug-brainstorm.md
+++ b/.claude/plugins/sdlc/skills/define/reference/bug-brainstorm.md
@@ -13,6 +13,8 @@ Internal checklist for the define skill. Weave these into natural conversation �
 - Are there related bugs or issues?
 - What's the fix scope? (one file, multiple areas, architectural)
 - Does this block or get blocked by any existing work?
+- Does this bug belong to an existing PI, epic, or feature — or is it standalone?
+- Are there technical considerations for the fix? (patterns to follow, constraints, root cause analysis)
 
 ## Context to load
 
@@ -20,10 +22,12 @@ Internal checklist for the define skill. Weave these into natural conversation �
 - Check recent git history for changes in affected areas
 - Check open issues for related work: `gh issue list --label "type:bug"`
 - Read `.claude/sdlc/prd/PRD.md` — check Architecture and Security Constraints if relevant
+- **If parented:** read the parent PI/epic/feature issue(s) via `gh issue view <parent> --json title,body,labels`. Load the parent's Technical Notes section if it exists — the bug's Technical Notes should build on parent context.
+- **If standalone:** skip parent loading — the bug's Technical Notes captures brainstorm context independently.
 
 ## Scope note
 
-Bugs have no size/decomposition concept (unlike features with size:small/large). A bug is always a single unit of work. There is no parent to load — bugs are peers to the hierarchy.
+Bugs have no size/decomposition concept (unlike features with size:small/large). A bug is always a single unit of work. Bugs can optionally be parented to a PI, epic, or feature, or remain standalone. Bugs are NOT tracked in parent checklists — they relate to parents via the `## Parent` section only.
 
 ## Research agent
 

--- a/.claude/plugins/sdlc/skills/define/reference/chore-brainstorm.md
+++ b/.claude/plugins/sdlc/skills/define/reference/chore-brainstorm.md
@@ -1,0 +1,36 @@
+# Chore Brainstorming Guide
+
+Internal checklist for the define skill. Weave these into natural conversation — do NOT ask them as a list.
+
+## Before you can draft, make sure you understand:
+
+- What's the specific work to perform?
+- Why does this need doing? (tech debt, cleanup, migration, infrastructure)
+- What are the acceptance criteria? (specific, testable)
+- What files will be created or modified?
+- Are there existing patterns to follow?
+- Any technical considerations or edge cases?
+- What blocks this or what does this block?
+- Does this chore belong to an existing PI, epic, or feature — or is it standalone?
+
+## Context to load
+
+- Read `.claude/sdlc/prd/PRD.md` — check Security Constraints and Architecture sections
+- **If parented:** read the parent PI/epic/feature issue(s) via `gh issue view <parent> --json title,body,labels`. Load the parent's Technical Notes section if it exists — the chore's Technical Notes should build on parent context.
+- **If standalone:** skip parent loading — the chore's Technical Notes captures brainstorm context independently.
+
+## Scope note
+
+Chores have no size/decomposition concept (unlike features with size:small/large). A chore is always a single unit of work. Chores can optionally be parented to a PI, epic, or feature, or remain standalone. Chores are NOT tracked in parent checklists — they relate to parents via the `## Parent` section only.
+
+## Research agent
+
+For chores with unclear file scope, dispatch a research agent:
+- Find files that will be modified (exact paths)
+- Identify existing patterns to follow
+- Check for related tests
+- Note utilities/helpers to reuse
+
+## Template reference
+
+Draft output format: `${CLAUDE_PLUGIN_ROOT}/templates/chore-template.md`

--- a/.claude/plugins/sdlc/skills/init/SKILL.md
+++ b/.claude/plugins/sdlc/skills/init/SKILL.md
@@ -49,7 +49,7 @@ Read .claude/sdlc/prd/PRD.md
 
 If the file does not exist, report:
 
-> "No PRD found at `.claude/sdlc/prd/PRD.md`. Run `sdlc:define prd` followed by `sdlc:create prd` first."
+> "No PRD found at `.claude/sdlc/prd/PRD.md`. Run `sdlc:define prd` first."
 
 STOP. Do not proceed further.
 
@@ -95,6 +95,12 @@ gh label create "priority:low" --color "c5def5" --force
 # Size labels (yellow-green gradient: lighter = smaller)
 gh label create "size:small" --color "e4e669" --force
 gh label create "size:large" --color "c9c642" --force
+
+# Severity labels (red gradient: darkest = most severe)
+gh label create "severity:critical" --color "b60205" --force
+gh label create "severity:high" --color "d93f0b" --force
+gh label create "severity:medium" --color "fbca04" --force
+gh label create "severity:low" --color "c5def5" --force
 
 # Triage (yellow)
 gh label create "triage" --color "fbca04" --force
@@ -159,13 +165,13 @@ If any are missing, suggest: "Consider enabling [plugin] for [benefit]."
 
 Present a summary:
 
-Compute label counts from the labels actually created in Step 3: count the universal labels (type + status + priority + size + triage) and the area labels separately, then sum for the total.
+Compute label counts from the labels actually created in Step 3: count the universal labels (type + status + priority + severity + size + triage) and the area labels separately, then sum for the total.
 
 ```
 ## SDLC Init Complete
 
 **Labels:**
-- Universal: <count> labels (type, status, priority, size, triage)
+- Universal: <count> labels (type, status, priority, severity, size, triage)
 - Project areas: <count> labels from PRD Label Taxonomy
 - Total: <sum> labels ensured
 

--- a/.claude/plugins/sdlc/templates/bug-template.md
+++ b/.claude/plugins/sdlc/templates/bug-template.md
@@ -1,6 +1,6 @@
 # Bug Template
 
-The canonical output format for Bug drafts. Bugs are GitHub Issues with `type:bug` label. Bugs are peers to the hierarchy — they have no parent epic or feature, only dependency relationships.
+The canonical output format for Bug drafts. Bugs are GitHub Issues with `type:bug` label. Bugs can be standalone (no parent) or optionally parented to a PI, epic, or feature.
 
 ## Frontmatter
 
@@ -12,6 +12,9 @@ severity: <critical|high|medium|low>
 priority: <critical|high|medium|low>
 areas: [<area labels>]
 status: draft
+parent-pi: <issue number>      # optional
+parent-epic: <issue number>    # optional
+parent-feature: <issue number> # optional
 ---
 ```
 
@@ -22,4 +25,16 @@ status: draft
 - `## Expected vs Actual Behavior` — What should happen vs what does happen
 - `## Affected Areas` — Which parts of the system are impacted
 - `## File Scope` — Known files involved (may be partial at capture, filled by define)
+- `## Technical Notes` — Implementation considerations, root cause analysis, patterns to follow
 - `## Dependencies` — Bidirectional format: `- Blocked by: #N` / `- Blocks: #N` (or `none`)
+
+## Conditional Sections
+
+- `## Parent` — **Only if `parent-pi`, `parent-epic`, or `parent-feature` is set**. **Omit entirely if standalone.**
+  - Show each set parent in hierarchy order: `PI: #<parent-pi>`, `Epic: #<parent-epic>`, `Feature: #<parent-feature>`
+  - Only include lines for parents that are set
+
+## Validation Rules
+
+- If any parent field is set, `## Parent` section MUST exist
+- If no parent fields are set, `## Parent` section MUST be omitted

--- a/.claude/plugins/sdlc/templates/chore-template.md
+++ b/.claude/plugins/sdlc/templates/chore-template.md
@@ -1,6 +1,6 @@
 # Chore Template
 
-The canonical output format for Chore drafts. Chores are GitHub Issues with `type:chore` label. Chores can be standalone (no parent) or parented to an epic/feature.
+The canonical output format for Chore drafts. Chores are GitHub Issues with `type:chore` label. Chores can be standalone (no parent) or optionally parented to a PI, epic, or feature.
 
 ## Frontmatter
 
@@ -11,6 +11,7 @@ name: <chore name>
 priority: <critical|high|medium|low>
 areas: [<area labels>]
 status: draft
+parent-pi: <issue number>      # optional
 parent-epic: <issue number>    # optional
 parent-feature: <issue number> # optional
 ---
@@ -22,16 +23,16 @@ parent-feature: <issue number> # optional
 - `## Task` — The specific work to perform
 - `## Acceptance Criteria` — Checklist of conditions for "done"
 - `## File Scope` — Files to create/modify
+- `## Technical Notes` — Implementation considerations, patterns to follow
 - `## Dependencies` — Bidirectional format: `- Blocked by: #N` / `- Blocks: #N` (or `none`)
 
 ## Conditional Sections
 
-- `## Parent` — **Only if `parent-epic` or `parent-feature` is set**. **Omit entirely if standalone.**
-  - Both set: `Epic: #<parent-epic>, Feature: #<parent-feature>`
-  - Only epic set: `Epic: #<parent-epic>`
-  - Only feature set: `Feature: #<parent-feature>`
+- `## Parent` — **Only if `parent-pi`, `parent-epic`, or `parent-feature` is set**. **Omit entirely if standalone.**
+  - Show each set parent in hierarchy order: `PI: #<parent-pi>`, `Epic: #<parent-epic>`, `Feature: #<parent-feature>`
+  - Only include lines for parents that are set
 
 ## Validation Rules
 
-- If `parent-epic` or `parent-feature` is set, `## Parent` section MUST exist
-- If neither parent is set, `## Parent` section MUST be omitted
+- If any parent field is set, `## Parent` section MUST exist
+- If no parent fields are set, `## Parent` section MUST be omitted

--- a/.claude/sdlc/prd/PRD.md
+++ b/.claude/sdlc/prd/PRD.md
@@ -63,6 +63,8 @@ PRD (git: .claude/sdlc/prd/PRD.md)
 | Epic | GitHub Issue (`type:epic`) | title, Overview, Success Criteria, Features checklist, Non-goals, Technical Notes, Dependencies |
 | Feature | GitHub Issue (`type:feature`) | title, Description, size (small/large), Acceptance Criteria, Stories checklist (if size:large), Non-goals, Technical Notes, Dependencies, Parent Epic link |
 | Story | GitHub Issue (`type:story`) | title, Description, Acceptance Criteria, File Scope, Technical Notes, Dependencies, Parent Epic + Feature links |
+| Bug | GitHub Issue (`type:bug`) | title, Description, severity, Reproduction Steps, Expected vs Actual Behavior, Affected Areas, File Scope, Technical Notes, Dependencies, optional Parent PI/Epic/Feature links |
+| Chore | GitHub Issue (`type:chore`) | title, Description, Task, Acceptance Criteria, File Scope, Technical Notes, Dependencies, optional Parent PI/Epic/Feature links |
 
 ### Label Taxonomy
 
@@ -72,6 +74,7 @@ PRD (git: .claude/sdlc/prd/PRD.md)
 | Status | `status:todo`, `status:in-progress`, `status:done`, `status:blocked` | Track workflow state |
 | Priority | `priority:critical`, `priority:high`, `priority:medium`, `priority:low` | Rank urgency |
 | Area | `area:skills`, `area:agents`, `area:templates`, `area:reference`, `area:manifest`, `area:artifacts`, `area:docs` | Group by architectural area |
+| Severity | `severity:critical`, `severity:high`, `severity:medium`, `severity:low` | Classify bug severity |
 | Triage | `triage` | Unprocessed captures awaiting definition |
 | Size | `size:small`, `size:large` | Classify feature complexity — small features are directly implementable, large features decompose into stories |
 


### PR DESCRIPTION
## Summary

Adds first-class bug and chore support across the SDLC plugin: optional parent associations (PI/epic/feature), Technical Notes propagation, dedicated execution and update agent references, severity labels in init, severity+priority prompts in capture, a dedicated chore brainstorm guide, and explicit Bug/Chore branches in the define Phase 8 decision tree.

## Test Plan

- [ ] **Bug template parent support:** Run `sdlc:define bug` with a parent epic — verify the draft includes `parent-pi`, `parent-epic`, `parent-feature` as optional fields and the `## Parent` section renders correctly with only the set parents
- [ ] **Bug template standalone:** Run `sdlc:define bug` without a parent — verify `## Parent` section is omitted and `## Technical Notes` is present
- [ ] **Chore template Technical Notes:** Run `sdlc:define chore` — verify `## Technical Notes` appears as a required section and `parent-pi` is available as an optional field
- [ ] **Bug brainstorm parent loading:** Run `sdlc:define bug` for a bug parented to a feature — verify the brainstorm loads the parent's Technical Notes and asks about technical considerations
- [ ] **Chore brainstorm standalone:** Run `sdlc:define chore` for a standalone chore — verify no parent loading occurs and the scope note reminds that chores are single units of work
- [ ] **Bug execution:** Dispatch create-agent for a bug draft — verify `severity:<level>` label is applied, no `status:` label, no branch created, no parent checklist updated
- [ ] **Chore execution:** Dispatch create-agent for a chore draft — verify no `status:` label, no branch, no parent checklist updated
- [ ] **Bug/chore update agents:** Dispatch update-agent for a bug and chore — verify read-modify-write pattern works, no Step 0 branch ensure, no parent cascade on title change
- [ ] **Init severity labels:** Run `sdlc:init` — verify `severity:critical` (b60205), `severity:high` (d93f0b), `severity:medium` (fbca04), `severity:low` (c5def5) are created and the summary counts include severity
- [ ] **Capture severity prompt:** Run `sdlc:capture bug: something is broken` — verify it prompts for severity and priority, and the `gh issue create` includes both labels
- [ ] **Define Phase 8 dispatch:** Run `sdlc:define bug` through to Phase 8 — verify it dispatches create-agent for bug (no children)
- [ ] **Define pre-flight:** Run `sdlc:define bug` with a non-existent parent epic — verify pre-flight check catches the missing parent
- [ ] **Impact analysis guard:** After creating a parented bug via define, verify Phase 9 does NOT suggest adding the bug to the parent's child checklist
- [ ] **Draft reviewer:** Submit a bug draft with parent fields — verify draft-reviewer does not reject it
- [ ] **PRD updates:** Verify PRD Label Taxonomy includes Severity category and Data Models includes Bug and Chore rows

---

Closes #69