### PR TITLE
feat(#63): version-bump-to-0-4-0

### DIFF
--- a/.claude/plugins/sdlc/.claude-plugin/plugin.json
+++ b/.claude/plugins/sdlc/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sdlc",
   "description": "Structured SDLC management — plan, decompose, execute, and ship work items using GitHub Issues and git-versioned artifacts.",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": {
     "name": "Raul Chakraborty",
     "url": "https://github.com/raulstechtips"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # SDLC Plugin for Claude Code
 
-Claude Code plugin (v0.3.0) providing structured SDLC management via GitHub Issues and git-versioned artifacts.
+Claude Code plugin (v0.4.0) providing structured SDLC management via GitHub Issues and git-versioned artifacts.
 
 ## Project Structure
 


### PR DESCRIPTION
## Summary

Bumps the SDLC plugin version from 0.3.0 to 0.4.0 in both `plugin.json` and `CLAUDE.md` to reflect the execution reliability fixes and Technical Notes propagation capability delivered in feature #59.

## Test Plan

- [ ] Verify `plugin.json` contains `"version": "0.4.0"` and remains valid JSON
- [ ] Verify `CLAUDE.md` header references `(v0.4.0)`
- [ ] Confirm no other files reference the old `0.3.0` version string

---

Closes #63